### PR TITLE
Add Dependabot cooldown windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
     groups:
       go-dependencies:
         patterns:
@@ -17,6 +22,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 14
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 21
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Adds `cooldown` blocks to both `updates:` entries in `.github/dependabot.yml`. Closes the two open zizmor `dependabot-cooldown` warnings (security/code-scanning #1 and #2).

## Values

Security-leaning profile, stricter for GitHub Actions (higher-value supply-chain target — they run in CI with `GITHUB_TOKEN`):

| Ecosystem | patch | minor | major | default |
|---|---|---|---|---|
| `gomod` | 3 | 7 | 14 | 7 |
| `github-actions` | 7 | 14 | 21 | 14 |

## Why

Without cooldown, Dependabot opens PRs on new releases within hours — a compromised release (cf. tj-actions/changed-files in March 2025) reaches CI before the community has flagged it. The 3-14 day window catches that class of attack. Security updates (CVE-driven) bypass cooldown by default, so known-critical patches still land immediately.

## Test plan

- [ ] zizmor passes on the changed file
- [ ] CI green