### PR TITLE
Add scaffold-smoke CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,21 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
 
+  scaffold-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Run scaffold smoke test
+        run: ./mise-tasks/scaffold-smoke
+
   zizmor:
     name: Audit workflows (zizmor)
     runs-on: ubuntu-latest

--- a/.mise.toml
+++ b/.mise.toml
@@ -40,14 +40,14 @@ run = "beans list --no-status completed --no-status scrapped"
 [tasks."example-hello"]
 description = "Run the hello world example (builds Tailwind CSS first)"
 run = [
-    "go tool burrow-tailwind -i example/hello/tailwind.css -o example/hello/static/app.min.css --minify",
+    "go tool burrow tailwind -i example/hello/tailwind.css -o example/hello/static/app.min.css --minify",
     'go run ./example/hello "$@"',
 ]
 
 [tasks."example-notes"]
 description = "Run the notes example application (builds Tailwind CSS first)"
 run = [
-    "go tool burrow-tailwind -i example/notes/tailwind.css -o example/notes/internal/app/static/app.min.css --minify",
+    "go tool burrow tailwind -i example/notes/tailwind.css -o example/notes/internal/app/static/app.min.css --minify",
     'go run ./example/notes/cmd/server "$@"',
 ]
 

--- a/go.mod
+++ b/go.mod
@@ -57,4 +57,4 @@ require (
 	modernc.org/sqlite v1.48.0 // indirect
 )
 
-tool github.com/oliverandrich/burrow/cmd/burrow-tailwind
+tool github.com/oliverandrich/burrow/cmd/burrow

--- a/mise-tasks/scaffold-smoke
+++ b/mise-tasks/scaffold-smoke
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE description="Smoke-test the burrow CLI: scaffold a project + generate an app, verify it builds and tests pass"
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+BURROW_BIN="$TMP/burrow"
+DEMO_DIR="$TMP/demo"
+
+echo ">>> Building burrow CLI"
+go build -o "$BURROW_BIN" ./cmd/burrow
+
+echo ">>> burrow new"
+"$BURROW_BIN" new "$DEMO_DIR" --module github.com/example/demo --description "scaffold-smoke"
+
+cd "$DEMO_DIR"
+# Pin to the local burrow source so the smoke test catches API drift
+# between the scaffolded output and unreleased burrow changes.
+go mod edit -replace="github.com/oliverandrich/burrow=$ROOT_DIR"
+go mod tidy
+go build ./...
+go test ./...
+
+echo ">>> burrow generate app"
+"$BURROW_BIN" generate app notes
+go mod tidy
+go build ./...
+go test ./...
+
+echo ">>> scaffold-smoke OK"


### PR DESCRIPTION
## Summary

Adds a `scaffold-smoke` CI job that exercises the `burrow new` and `burrow generate app` flow end-to-end on every PR, so API drift between burrow and the scaffolded output is caught at PR time instead of post-release.

## What it does

1. Builds the `burrow` CLI from the current PR's source
2. Scaffolds a fresh project into a tempdir (`burrow new` + `--module github.com/example/demo`)
3. Pins the scaffolded project to the local burrow source via `go mod edit -replace` — so the smoke catches unreleased API changes
4. `go mod tidy + go build ./... + go test ./...`
5. Runs `burrow generate app notes` inside the scaffolded project
6. Re-verifies tidy + build + test

Script lives in `mise-tasks/scaffold-smoke` so `mise run scaffold-smoke` works locally — same code path as CI.

## Tooling cleanup bundled in

- `go.mod` tool directive bumped `cmd/burrow-tailwind` → `cmd/burrow` (burrow's own tooling now uses the consolidated CLI; existing user projects with the old directive still work via the deprecation shim until v0.22).
- `.mise.toml` `example-hello` and `example-notes` use `go tool burrow tailwind` (no more deprecation notice when running the bundled examples).

## Test plan

- [x] `mise run scaffold-smoke` clean locally
- [x] `go test ./...` clean
- [ ] New job runs green in CI

## Follow-up (not in this PR)

Adding `scaffold-smoke` as a required status check on `main` — one `gh api` call away. Useful if you want it to actually block merges.