### PR TITLE
burrow new: mise-aware bootstrap output + auto git init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- **`burrow new` bootstrap UX.** The destination is now auto-initialized as a git repo when `git` is on `PATH` (no initial commit — that's the user's choice). The printed Next-steps switches to a mise-aware two-liner (`mise run setup` + `mise run dev`) when mise is detected, falling back to `go mod tidy && go run` when it isn't. The scaffolded `.mise.toml`'s `[tasks.setup]` is now a one-stop bootstrap: `mise install` + `go mod tidy` + dev-key generation + `pre-commit install` (when `.git/` exists). Docs and README updated to lead with the mise path. No `--no-git` flag — second `git init` is a harmless no-op for users in CI.
+
 ## 0.21.0 — 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ The fastest path is the bundled `burrow` CLI, which scaffolds a project with the
 ```bash
 go install github.com/oliverandrich/burrow/cmd/burrow@latest
 burrow new myapp --module github.com/you/myapp
-cd myapp && go run ./cmd/myapp
+cd myapp && mise run setup && mise run dev
 ```
+
+Without `mise`, the scaffold prints a `go mod tidy && go run ./cmd/myapp` fallback.
 
 Or build from scratch:
 

--- a/cmd/burrow/new.go
+++ b/cmd/burrow/new.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
+	"os"
 	"os/exec"
 	"path"
 	"strconv"
@@ -23,9 +25,10 @@ func newCommand() *cli.Command {
 		Name:      "new",
 		Usage:     "Scaffold a new burrow project",
 		ArgsUsage: "<dir>",
-		Description: `Scaffold a new burrow project at <dir>. The directory must not exist
-or must be empty. After scaffolding, cd into the project and run
-` + "`go mod tidy && go run ./cmd/<name>`.",
+		Description: `Scaffold a new burrow project at <dir>. The directory must not
+exist or must be empty. When git is on PATH, the destination is
+initialized as a git repository. The printed Next-steps adapt to
+whether mise is installed.`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "module",
@@ -49,7 +52,7 @@ or must be empty. After scaffolding, cd into the project and run
 	}
 }
 
-func runNew(_ context.Context, cmd *cli.Command) error {
+func runNew(ctx context.Context, cmd *cli.Command) error {
 	if cmd.NArg() != 1 {
 		return fmt.Errorf("burrow new: exactly one <dir> argument is required")
 	}
@@ -92,19 +95,65 @@ func runNew(_ context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	fmt.Printf(nextStepsTemplate, destDir, destDir, projectName)
+	bootstrapGit(ctx, destDir, os.Stderr, defaultHasGit, defaultInitRepo)
+	fmt.Print(nextStepsMessage(destDir, projectName, defaultHasMise()))
 	return nil
 }
 
-const nextStepsTemplate = `Project scaffolded at %s.
+func nextStepsMessage(destDir, projectName string, miseAvailable bool) string {
+	if miseAvailable {
+		return fmt.Sprintf(nextStepsMiseTemplate, destDir)
+	}
+	return fmt.Sprintf(nextStepsPlainTemplate, destDir, projectName)
+}
+
+const nextStepsMiseTemplate = `Project scaffolded at %[1]s.
 
 Next steps:
-  cd %s
+  cd %[1]s
+  mise run setup     # installs tools, fetches deps, generates dev keys, installs git hooks
+  mise run dev       # live-reload server
+
+Docs: https://burrow.dev/
+`
+
+const nextStepsPlainTemplate = `Project scaffolded at %[1]s.
+
+Next steps:
+  cd %[1]s
   go mod tidy
-  go run ./cmd/%s
+  go run ./cmd/%[2]s
 
 Docs: https://burrow.dev/  (use "go tool burrow tailwind ..." for CSS builds)
 `
+
+// bootstrapGit warns instead of aborting — the scaffold already wrote
+// files to disk, so a missing git or failed init shouldn't undo the work.
+func bootstrapGit(ctx context.Context, destDir string, errW io.Writer, hasGit func() bool, initRepo func(context.Context, string) error) {
+	if !hasGit() {
+		_, _ = fmt.Fprintln(errW, "warning: git not on PATH — skipping `git init`")
+		return
+	}
+	if err := initRepo(ctx, destDir); err != nil {
+		_, _ = fmt.Fprintln(errW, "warning: git init failed:", err)
+	}
+}
+
+func defaultHasMise() bool {
+	_, err := exec.LookPath("mise")
+	return err == nil
+}
+
+func defaultHasGit() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+func defaultInitRepo(ctx context.Context, dir string) error {
+	cmd := exec.CommandContext(ctx, "git", "init", "-q")
+	cmd.Dir = dir
+	return cmd.Run()
+}
 
 // validateModulePath rejects empty or obviously malformed module paths.
 // Full validation is delegated to `go mod tidy`.

--- a/cmd/burrow/new_test.go
+++ b/cmd/burrow/new_test.go
@@ -1,10 +1,70 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNextStepsMessage(t *testing.T) {
+	t.Run("with mise present", func(t *testing.T) {
+		got := nextStepsMessage("warren", "warren", true)
+		assert.Contains(t, got, "mise run setup")
+		assert.Contains(t, got, "mise run dev")
+		assert.NotContains(t, got, "go mod tidy")
+		assert.NotContains(t, got, "go run ./cmd/warren")
+	})
+
+	t.Run("without mise", func(t *testing.T) {
+		got := nextStepsMessage("warren", "warren", false)
+		assert.Contains(t, got, "go mod tidy")
+		assert.Contains(t, got, "go run ./cmd/warren")
+		assert.NotContains(t, got, "mise")
+	})
+
+	t.Run("destDir is interpolated", func(t *testing.T) {
+		got := nextStepsMessage("path/to/myapp", "myapp", true)
+		assert.Contains(t, got, "cd path/to/myapp")
+	})
+}
+
+func TestBootstrapGit(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("git present, init succeeds", func(t *testing.T) {
+		var initCalledWith string
+		bootstrapGit(ctx, "/some/dir", io.Discard,
+			func() bool { return true },
+			func(_ context.Context, dir string) error { initCalledWith = dir; return nil },
+		)
+		assert.Equal(t, "/some/dir", initCalledWith)
+	})
+
+	t.Run("git present, init fails", func(t *testing.T) {
+		var buf bytes.Buffer
+		bootstrapGit(ctx, "/some/dir", &buf,
+			func() bool { return true },
+			func(context.Context, string) error { return errors.New("permission denied") },
+		)
+		assert.Contains(t, buf.String(), "git init failed")
+		assert.Contains(t, buf.String(), "permission denied")
+	})
+
+	t.Run("git missing", func(t *testing.T) {
+		var buf bytes.Buffer
+		initCalled := false
+		bootstrapGit(ctx, "/some/dir", &buf,
+			func() bool { return false },
+			func(context.Context, string) error { initCalled = true; return nil },
+		)
+		assert.False(t, initCalled, "init must not be called when git is missing")
+		assert.Contains(t, buf.String(), "git not on PATH")
+	})
+}
 
 func TestGuessGitUser(t *testing.T) {
 	for _, tc := range []struct {

--- a/cmd/burrow/templates/project/.mise.toml
+++ b/cmd/burrow/templates/project/.mise.toml
@@ -86,12 +86,26 @@ depends = ["css"]
 run = "goreleaser release --clean --skip=docker"
 
 [tasks.setup]
-description = "Verify dev tools + install git hooks"
+description = "Bootstrap the project: install pinned tools, fetch deps, generate dev secrets, install git hooks"
+depends = ["ensure-dev-keys"]
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
-echo "Installed via mise:"
-mise list --installed | sed "s/^/  /"
-echo
-echo "Run 'pre-commit install' to wire up git hooks."
+
+echo "==> mise install"
+mise install
+
+echo "==> go mod tidy"
+go mod tidy
+
+if [ -d .git ]; then
+    if command -v pre-commit >/dev/null 2>&1; then
+        echo "==> pre-commit install"
+        pre-commit install
+    else
+        echo "==> pre-commit not on PATH — skipping git hooks" >&2
+    fi
+else
+    echo "==> no .git/ — skipping git hooks"
+fi
 '''

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,8 +15,10 @@ boilerplate:
 ```bash
 go install github.com/oliverandrich/burrow/cmd/burrow@latest
 burrow new myapp --module github.com/you/myapp
-cd myapp && go mod tidy && go run ./cmd/myapp
+cd myapp && mise run setup && mise run dev
 ```
+
+Without `mise`, use the `go mod tidy && go run ./cmd/myapp` flow the scaffold prints instead.
 
 See [Tooling](tooling.md) for the full sub-command reference.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -10,8 +10,10 @@ Build a minimal working application with a custom homepage and health check endp
     ```bash
     go install github.com/oliverandrich/burrow/cmd/burrow@latest
     burrow new myapp --module github.com/you/myapp
-    cd myapp && go run ./cmd/myapp
+    cd myapp && mise run setup && mise run dev
     ```
+
+    Without `mise`, the scaffold prints a `go mod tidy && go run ./cmd/myapp` fallback.
 
     See [Tooling](tooling.md) for the full set of flags.
 

--- a/docs/getting-started/tooling.md
+++ b/docs/getting-started/tooling.md
@@ -20,9 +20,11 @@ go install github.com/oliverandrich/burrow/cmd/burrow@latest
 ```bash
 burrow new myapp --module github.com/you/myapp
 cd myapp
-go mod tidy
-go run ./cmd/myapp
+mise run setup     # installs tools, fetches deps, generates dev keys, installs git hooks
+mise run dev       # live-reload server
 ```
+
+When `mise` isn't installed, the scaffold prints a `go mod tidy && go run ./cmd/myapp` fallback instead.
 
 The scaffold ships:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,8 +35,10 @@ The fastest path is the bundled `burrow` CLI, which scaffolds a full project wit
 ```bash
 go install github.com/oliverandrich/burrow/cmd/burrow@latest
 burrow new myapp --module github.com/you/myapp
-cd myapp && go run ./cmd/myapp
+cd myapp && mise run setup && mise run dev
 ```
+
+Without `mise`, the scaffold prints a `go mod tidy && go run ./cmd/myapp` fallback.
 
 See [Tooling](getting-started/tooling.md) for the full sub-command
 reference, or follow the from-scratch example below to understand what

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -67,13 +67,36 @@ version that produced it. Resolution order:
 2. `git describe --tags --abbrev=0 --match 'v*'` in the cwd — covers
    `go run ./cmd/burrow` from inside the burrow source tree.
 
+### Auto `git init`
+
+When `git` is on `PATH`, the destination directory is initialized as a
+git repository (`git init -q`). The initial commit is left to the user.
+When git is missing, a stderr warning is printed and the scaffold
+continues without `.git/`.
+
+### Next-steps output
+
+The printed Next-steps adapt to whether `mise` is installed:
+
+```bash
+# With mise on PATH (recommended path — the scaffold pins mise tasks)
+cd myapp
+mise run setup     # installs tools, fetches deps, generates dev keys, installs git hooks
+mise run dev       # live-reload server
+
+# Without mise
+cd myapp
+go mod tidy
+go run ./cmd/myapp
+```
+
 ### Example
 
 ```bash
 burrow new myapp --module github.com/me/myapp --description "My demo app"
 cd myapp
-go mod tidy
-go run ./cmd/myapp
+mise run setup
+mise run dev
 # → http://localhost:8080
 ```
 


### PR DESCRIPTION
## Summary

Polishes the post-scaffold UX of `burrow new` so the printed Next-steps match how most users actually start: a git repo, a mise bootstrap task, then live-reload dev. Two behaviour changes plus matching docs.

## Behaviour

- **Auto `git init`** — when `git` is on PATH, the destination directory is initialized as a git repository (no initial commit; that's the user's choice). When git is missing, a stderr warning is printed and the scaffold continues.
- **mise-aware Next-steps** — when `mise` is on PATH, the printed output is:

  ```
  cd myapp
  mise run setup     # installs tools, fetches deps, generates dev keys, installs git hooks
  mise run dev       # live-reload server
  ```

  Without mise, the existing `cd myapp && go mod tidy && go run ./cmd/myapp` flow is shown instead.

- **Scaffolded `[tasks.setup]`** is now a one-stop bootstrap: `mise install` + `go mod tidy` + dev-key generation (via the existing `ensure-dev-keys` task as `depends`) + `pre-commit install` when `.git/` and pre-commit are present. Tools are pinned in `.mise.toml`, so `mise install` resolves them; subsequent runs are no-ops.

## Tests

- 6 new test cases for the two helpers (`nextStepsMessage`, `bootstrapGit`) — both branches, plus the git-failure path. Lookup-side defaults (`defaultHasMise`, `defaultHasGit`, `defaultInitRepo`) inject for testability.
- `mise run scaffold-smoke` clean (CI's existing job exercises the new flow end-to-end).

## Docs

Quickstart, installation, README, `docs/index.md`, and the CLI reference (`docs/reference/cli.md`) all lead with the mise path and note the plain-go fallback. `docs/reference/cli.md` gains explicit "Auto git init" and "Next-steps output" sections.

## Decisions

- **No `--no-git` flag** — second `git init` is a no-op for users in CI who already cloned/inited.
- **`mise install` folded into `mise run setup`** — sacrifices a sliver of mise-convention purity (separate tool install vs. project tasks) for a 2-line Next-steps instead of 3. Idempotent on subsequent runs.

## Test plan

- [x] `go test ./...` + `golangci-lint run ./...` clean
- [x] Local end-to-end: `burrow new myapp --module github.com/me/myapp` produces `.git/` + mise-aware output
- [x] `mise run scaffold-smoke` clean
- [ ] CI green