### PR TITLE
Drop "Django-inspired" framing from scaffold + forms doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- **Dropped "Django-inspired" framing from current-state copy.** Scaffolded project's homepage and README, plus the `forms` package doc, now describe Burrow on its own terms. The broader marketing comparison in burrow's own README and `docs/index.md` ("for Go developers who want something like Django, Rails, or Flask") is kept intentionally.
+
 ## 0.21.1 — 2026-05-18
 
 ### Changed

--- a/cmd/burrow/templates/project/README.md
+++ b/cmd/burrow/templates/project/README.md
@@ -8,7 +8,7 @@
 
 __ProjectDescription__
 
-Built on [Burrow](https://github.com/oliverandrich/burrow) (Django-inspired Go web framework), Tailwind v4 (utility-first CSS, dark mode via `prefers-color-scheme`), [htmx](https://htmx.org/) (server-driven interactivity), SQLite via [Den](https://github.com/oliverandrich/den) (pure Go, no CGO).
+Built on [Burrow](https://github.com/oliverandrich/burrow) (modular Go web framework), Tailwind v4 (utility-first CSS, dark mode via `prefers-color-scheme`), [htmx](https://htmx.org/) (server-driven interactivity), SQLite via [Den](https://github.com/oliverandrich/den) (pure Go, no CGO).
 
 ## Quick Start
 

--- a/cmd/burrow/templates/project/internal/app/templates/pages/home.html
+++ b/cmd/burrow/templates/project/internal/app/templates/pages/home.html
@@ -11,7 +11,7 @@
             <strong class="text-base">Burrow</strong>
         </header>
         <p class="text-sm text-gray-700 dark:text-gray-300">
-            Built on the Burrow web framework — a Django-inspired Go framework with contrib apps, middleware, and template rendering.
+            Built on the Burrow web framework — modular Go apps with routes, middleware, document storage, and template rendering.
         </p>
     </article>
     <article class="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">

--- a/forms/interfaces.go
+++ b/forms/interfaces.go
@@ -1,5 +1,5 @@
-// Package forms provides Django-style form structs for creation, binding,
-// validation, and field metadata extraction.
+// Package forms provides struct-based form definitions for creation,
+// binding, validation, and field metadata extraction.
 package forms
 
 import "context"


### PR DESCRIPTION
## Summary

Three current-state name-drops of "Django" removed from copy that describes Burrow today:

- `cmd/burrow/templates/project/internal/app/templates/pages/home.html` — scaffolded homepage
- `cmd/burrow/templates/project/README.md` — scaffolded README intro
- `forms/interfaces.go` — package doc comment

The broader marketing comparison in burrow's own README and `docs/index.md` ("for Go developers who want something like Django, Rails, or Flask") is kept intentionally as a positioning anchor. Historical CHANGELOG entries are left as release history.

## Test plan

- [x] `go test ./...` + `golangci-lint run ./...` clean
- [x] `mise run scaffold-smoke` clean
- [ ] CI green