### PR TITLE
Drop gohatch references from scaffolded README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 ### Changed
 
 - **Dropped "Django-inspired" framing from current-state copy.** Scaffolded project's homepage and README, plus the `forms` package doc, now describe Burrow on its own terms. The broader marketing comparison in burrow's own README and `docs/index.md` ("for Go developers who want something like Django, Rails, or Flask") is kept intentionally.
+- **Scaffolded project's README rewritten for post-scaffold reality.** Quick Start leads with `mise run setup && mise run dev` instead of the obsolete `gohatch` invocation; the gohatch requirement and the "Template Variables" metadata section are gone; the Development table uses `burrow tailwind`.
 
 ## 0.21.1 — 2026-05-18
 

--- a/cmd/burrow/templates/project/README.md
+++ b/cmd/burrow/templates/project/README.md
@@ -13,12 +13,8 @@ Built on [Burrow](https://github.com/oliverandrich/burrow) (modular Go web frame
 ## Quick Start
 
 ```bash
-# Create a new project from the template
-gohatch github.com/oliverandrich/go-burrow-template github.com/you/your-app
-cd your-app
-
-# Install pinned tools (Go, Tailwind, linters, goreleaser, ...) via mise
-mise install
+# Bootstrap the project (mise install + go mod tidy + dev keys + git hooks)
+mise run setup
 
 # Run the development server with live reload
 mise run dev
@@ -29,17 +25,6 @@ Server: <http://localhost:8080>.
 ## Requirements
 
 - [mise](https://mise.jdx.dev/) — installs every other tool pinned in `.mise.toml`
-- [gohatch](https://github.com/oliverandrich/gohatch) — instantiates the template
-
-## Template Variables
-
-`gohatch` replaces these placeholders during scaffolding:
-
-| Placeholder              | Replaced with                        |
-| ------------------------ | ------------------------------------ |
-| `__ProjectName__`        | Binary name (last path segment)      |
-| `__ProjectDescription__` | Project description (from `-d` flag) |
-| `__GitUser__`            | GitHub user/org (second path segment)|
 
 ## Development
 
@@ -47,7 +32,7 @@ Server: <http://localhost:8080>.
 
 | Task | What it does |
 |---|---|
-| `mise run dev` | air (live reload). Every rebuild reruns `burrow-tailwind`, so the embedded CSS bundle stays in sync with template utility classes. |
+| `mise run dev` | air (live reload). Every rebuild reruns `burrow tailwind`, so the embedded CSS bundle stays in sync with template utility classes. |
 | `mise run test` | `go test ./...` via tparse |
 | `mise run lint` | golangci-lint |
 | `mise run fmt` | gofmt + goimports |
@@ -75,7 +60,7 @@ On first `mise run dev` a `.dev-keys` file is generated with persistent `SESSION
 │               └── home.html
 ├── tailwind.css                 # Tailwind entrypoint (imports source list)
 ├── Dockerfile                   # Multi-arch image (linux/amd64 + linux/arm64)
-├── go.mod                       # Pinned to burrow v0.20+
+├── go.mod                       # Pinned burrow + Den versions
 ├── .mise.toml                   # Tool pins + task runner
 ├── .golangci.yml                # Linter config
 └── .goreleaser.yaml             # Release config (archives + Docker image)


### PR DESCRIPTION
## Summary

The scaffolded project's `README.md` still described how to instantiate the template via `gohatch`. With the bundled `burrow new` CLI shipped in v0.21, the project is already on disk when the user reads this README — the doc should target "you have this repo cloned, here's how to run it" instead.

## Changes

- **Quick Start**: drops the `gohatch github.com/oliverandrich/go-burrow-template ...` line; leads with `mise run setup && mise run dev`
- **Requirements**: drops the gohatch bullet — only `mise` is needed
- **"Template Variables" section**: removed entirely (scaffolder-internal metadata, not project doc — `__ProjectName__` etc. are already substituted by the time the user sees the README)
- **Development table**: stale `burrow-tailwind` reference rewritten to `burrow tailwind`
- **Project Structure**: tidied the go.mod comment (was "Pinned to burrow v0.20+", now "Pinned burrow + Den versions")

## Test plan

- [x] `mise run scaffold-smoke` clean
- [ ] CI green