### PR TITLE
feat(forms): nested struct fields render as subforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 - **`forms.BoundField.Label` and `forms.Choice.Label` are now auto-translated** by `extractFields` via the same Label-as-key convention as `NavItem.Label`. Templates render `{{ .Label }}` and get the locale-appropriate string for free — no `{{ t .Label }}` wrapping needed. Contribute translations keyed by the English `verbose:` / `Choice.Label` value. Added `Form.WithContext(ctx)` for building forms outside the request lifecycle (background jobs, CLI). See [forms: Translating field labels](guide/forms.md#translating-field-labels).
 - **`contrib/{admin,auth,jobs}` short structured-key labels migrated to Label-as-key** in line with the new convention. Filter tabs, action buttons, table headers, field labels, status badges — i.e. anything that's a single-word or short-phrase UI label — now use bare English keys (`{{ t "Active" }}` instead of `{{ t "admin-users-active" }}`). Full sentences, prompts, confirmations, and plural variants keep their structured keys. Translation TOMLs now have a "Field labels" block at the top followed by structured "Messages" — see [i18n: Labels vs. Messages](guide/i18n.md#labels-vs-messages) for the rule.
 
+### Added
+
+- **`forms` package: nested-struct subform support.** Struct-typed form fields now render as **subforms** — `extractFields` recurses one level into the nested struct and exposes its fields under the parent's `BoundField.SubFields`. Nested `FormName` values follow the `parent.child` convention (e.g. `profile.name`) so `burrow.Bind` decodes them and validation errors route to the correct nested field. `time.Time` is excluded (keeps the `"date"` widget); pointer-to-struct is dereferenced (nil → zero-value sub-fields); recursion is capped at one level. Templates dispatch on `Type == "subform"` and iterate `.SubFields` — see [forms: Nested struct fields](guide/forms.md#nested-struct-fields-subforms).
+
 ## 0.21.2 — 2026-05-18
 
 ### Changed

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -229,11 +229,12 @@ func (a *App) Create(w http.ResponseWriter, r *http.Request) error {
 | `FormName` | `string` | HTML name attribute |
 | `Label` | `string` | Human-readable label (auto-translated, see [below](#translating-field-labels)) |
 | `HelpText` | `string` | Help text for the field |
-| `Type` | `string` | HTML input type (`text`, `textarea`, `select`, etc.) |
+| `Type` | `string` | HTML input type (`text`, `textarea`, `select`, `subform`, etc.; see [Nested struct fields](#nested-struct-fields-subforms)) |
 | `Value` | `any` | Current field value |
 | `Required` | `bool` | Whether the field is required |
 | `ReadOnly` | `bool` | Whether the field is read-only (render as disabled) |
 | `Choices` | `[]Choice` | Options for select fields — `Choice.Label` is auto-translated too |
+| `SubFields` | `[]BoundField` | Populated when `Type == "subform"` (see [Nested struct fields](#nested-struct-fields-subforms)) |
 | `Errors` | `[]string` | Validation errors for this field |
 
 ### Translating field labels
@@ -272,6 +273,26 @@ forms.WithChoices[User]("Role", []forms.Choice{
 
 `extractFields` translates each Label as it builds the field, covering both `WithChoices` (static) and `WithChoicesFunc` (dynamic) sources.
 
+### Nested struct fields (subforms)
+
+Struct-typed fields render as **subforms** — `Fields()` recurses one level into the nested struct and exposes its fields under the parent's `SubFields`:
+
+```go
+type ArticleForm struct {
+    Title   string `form:"title" verbose:"Title"`
+    Profile struct {
+        Name string `form:"name" verbose:"Name" validate:"required"`
+        Bio  string `form:"bio"  verbose:"Bio"  widget:"textarea"`
+    } `form:"profile" verbose:"Profile"`
+}
+```
+
+The parent `Profile` BoundField has `Type == "subform"` and `SubFields` containing two BoundFields. Nested `FormName` values follow the `parent.child` convention (`profile.name`, `profile.bio`) which matches what [`burrow.Bind`](validation.md) expects on submit. Validation errors with a dotted `Field` name (e.g. `profile.name`) attach to the nested BoundField via the same mechanism as flat fields.
+
+Pointer-to-struct (`*Profile`) is dereferenced; a nil pointer still yields a subform with zero-value sub-fields. `time.Time` is excluded (keeps the `"date"` widget). Recursion is **one level only** — a struct nested inside a subform renders flat as text. `form:"-"` on the parent struct field skips the whole subform.
+
+Templates render subforms by dispatching on `Type == "subform"` and iterating `.SubFields`. The [Example Template](#example-template) below shows the pattern: factor the per-field render into a named template (`myapp/field`) so the subform branch can call it back on each `SubField` — the one-level recursion cap guarantees those inner calls always hit a non-subform branch.
+
 ### Example Template
 
 ```html
@@ -285,49 +306,58 @@ forms.WithChoices[User]("Role", []forms.Choice{
     </div>
     {{- end }}
 
-    {{ range .Fields -}}
-    <div class="mb-3">
-        <label for="{{ .FormName }}" class="form-label">
-            {{ .Label }}{{ if .Required }} *{{ end }}
-        </label>
-
-        {{ if eq .Type "textarea" -}}
-        <textarea class="form-control{{ if .Errors }} is-invalid{{ end }}"
-            id="{{ .FormName }}" name="{{ .FormName }}" rows="3">{{ .Value }}</textarea>
-
-        {{- else if eq .Type "select" -}}
-        <select class="form-select{{ if .Errors }} is-invalid{{ end }}"
-            id="{{ .FormName }}" name="{{ .FormName }}">
-            <option value="">—</option>
-            {{ range .Choices -}}
-            <option value="{{ .Value }}"{{ if eq .Value $.Value }} selected{{ end }}>{{ .Label }}</option>
-            {{- end }}
-        </select>
-
-        {{- else if eq .Type "checkbox" -}}
-        <div class="form-check">
-            <input type="checkbox" class="form-check-input{{ if .Errors }} is-invalid{{ end }}"
-                id="{{ .FormName }}" name="{{ .FormName }}" value="true"{{ if .Value }} checked{{ end }}>
-        </div>
-
-        {{- else -}}
-        <input type="{{ .Type }}" class="form-control{{ if .Errors }} is-invalid{{ end }}"
-            id="{{ .FormName }}" name="{{ .FormName }}" value="{{ .Value }}"
-            {{ if .Required }}required{{ end }}>
-        {{- end }}
-
-        {{ if .HelpText -}}
-        <div class="form-text">{{ .HelpText }}</div>
-        {{- end }}
-
-        {{ range .Errors -}}
-        <div class="invalid-feedback">{{ . }}</div>
-        {{- end }}
-    </div>
-    {{- end }}
+    {{ range .Fields }}{{ template "myapp/field" . }}{{ end }}
 
     <button type="submit" class="btn btn-primary">Save</button>
 </form>
+{{- end }}
+
+{{ define "myapp/field" -}}
+{{ if eq .Type "subform" -}}
+<fieldset class="mb-3">
+    <legend>{{ .Label }}</legend>
+    {{ range .SubFields }}{{ template "myapp/field" . }}{{ end }}
+</fieldset>
+{{- else -}}
+<div class="mb-3">
+    <label for="{{ .FormName }}" class="form-label">
+        {{ .Label }}{{ if .Required }} *{{ end }}
+    </label>
+
+    {{ if eq .Type "textarea" -}}
+    <textarea class="form-control{{ if .Errors }} is-invalid{{ end }}"
+        id="{{ .FormName }}" name="{{ .FormName }}" rows="3">{{ .Value }}</textarea>
+
+    {{- else if eq .Type "select" -}}
+    <select class="form-select{{ if .Errors }} is-invalid{{ end }}"
+        id="{{ .FormName }}" name="{{ .FormName }}">
+        <option value="">—</option>
+        {{ range .Choices -}}
+        <option value="{{ .Value }}"{{ if eq .Value $.Value }} selected{{ end }}>{{ .Label }}</option>
+        {{- end }}
+    </select>
+
+    {{- else if eq .Type "checkbox" -}}
+    <div class="form-check">
+        <input type="checkbox" class="form-check-input{{ if .Errors }} is-invalid{{ end }}"
+            id="{{ .FormName }}" name="{{ .FormName }}" value="true"{{ if .Value }} checked{{ end }}>
+    </div>
+
+    {{- else -}}
+    <input type="{{ .Type }}" class="form-control{{ if .Errors }} is-invalid{{ end }}"
+        id="{{ .FormName }}" name="{{ .FormName }}" value="{{ .Value }}"
+        {{ if .Required }}required{{ end }}>
+    {{- end }}
+
+    {{ if .HelpText -}}
+    <div class="form-text">{{ .HelpText }}</div>
+    {{- end }}
+
+    {{ range .Errors -}}
+    <div class="invalid-feedback">{{ . }}</div>
+    {{- end }}
+</div>
+{{- end }}
 {{- end }}
 ```
 

--- a/forms/field.go
+++ b/forms/field.go
@@ -14,17 +14,22 @@ import (
 // [i18n.T] by [extractFields], so the English Label doubles as the i18n
 // message ID. Templates render {{ .Label }} as-is — no {{ t }} wrapping
 // needed. See docs/guide/i18n.md for the Label-as-key convention.
+//
+// When Type is "subform", SubFields holds the nested struct's BoundFields
+// (one level of recursion). Their FormName uses the parent.child convention
+// (e.g. "profile.name"), which matches the [burrow.Bind] decoder.
 type BoundField struct { //nolint:govet // fieldalignment: readability over optimization
-	Name     string   // Go struct field name
-	FormName string   // HTML field name (from form tag or lowercase)
-	Label    string   // translated from verbose_name/verbose tag
-	HelpText string   // from help_text tag
-	Type     string   // "text", "number", "textarea", "select", "checkbox", "date", "email", "hidden"
-	Value    any      // current value
-	Required bool     // from validate:"required"
-	ReadOnly bool     // render as plain text, not editable
-	Choices  []Choice // static or dynamic, with translated labels
-	Errors   []string // field-specific error messages
+	Name      string       // Go struct field name
+	FormName  string       // HTML field name (from form tag or lowercase)
+	Label     string       // translated from verbose_name/verbose tag
+	HelpText  string       // from help_text tag
+	Type      string       // "text", "number", "textarea", "select", "checkbox", "date", "email", "hidden", "subform"
+	Value     any          // current value
+	Required  bool         // from validate:"required"
+	ReadOnly  bool         // render as plain text, not editable
+	Choices   []Choice     // static or dynamic, with translated labels
+	SubFields []BoundField // populated when Type == "subform"
+	Errors    []string     // field-specific error messages
 }
 
 // Choice represents a single option in a select or radio field. Label is
@@ -40,6 +45,26 @@ type Choice struct {
 // (keyed by Go struct field name) are omitted.
 func extractFields[T any](ctx context.Context, instance *T, validationErr *burrow.ValidationError, choices map[string][]Choice, exclude, readOnly map[string]struct{}) []BoundField {
 	v := reflect.ValueOf(instance).Elem()
+	return walkStructFields(ctx, v, validationErr, "", choices, exclude, readOnly, true)
+}
+
+// walkStructFields builds the BoundField slice for a struct value. When
+// allowSubforms is true, struct-typed fields recurse one level (their
+// SubFields are populated and FormNames are prefixed by the parent's name).
+// On the recursive call allowSubforms is false, capping nesting at one level.
+//
+// formNamePrefix is the parent's FormName when recursing (empty at top
+// level); nested FormNames follow the parent.child convention so they match
+// validation errors emitted by burrow.Bind.
+func walkStructFields(
+	ctx context.Context,
+	v reflect.Value,
+	validationErr *burrow.ValidationError,
+	formNamePrefix string,
+	choices map[string][]Choice,
+	exclude, readOnly map[string]struct{},
+	allowSubforms bool,
+) []BoundField {
 	t := v.Type()
 
 	var fields []BoundField
@@ -59,9 +84,13 @@ func extractFields[T any](ctx context.Context, instance *T, validationErr *burro
 		}
 
 		_, isReadOnly := readOnly[sf.Name]
+		formName := fieldFormName(sf)
+		if formNamePrefix != "" {
+			formName = formNamePrefix + "." + formName
+		}
 		bf := BoundField{
 			Name:     sf.Name,
-			FormName: fieldFormName(sf),
+			FormName: formName,
 			Label:    i18n.T(ctx, parseLabel(sf)),
 			HelpText: parseHelpText(sf),
 			Value:    fieldValue(v.Field(i)),
@@ -69,13 +98,19 @@ func extractFields[T any](ctx context.Context, instance *T, validationErr *burro
 			ReadOnly: isReadOnly,
 		}
 
-		// Determine type: widget tag > choices > inferred from Go type.
-		if w := parseWidget(sf); w != "" {
-			bf.Type = w
-		} else if c := parseChoices(sf); len(c) > 0 {
+		// Determine type: widget tag > choices > subform (one level) > inferred.
+		widget := parseWidget(sf)
+		tagChoices := parseChoices(sf)
+		switch {
+		case widget != "":
+			bf.Type = widget
+		case len(tagChoices) > 0:
 			bf.Type = "select"
-			bf.Choices = c
-		} else {
+			bf.Choices = tagChoices
+		case allowSubforms && isSubformType(sf.Type):
+			bf.Type = "subform"
+			bf.SubFields = walkStructFields(ctx, subformValue(v.Field(i)), validationErr, formName, nil, nil, nil, false)
+		default:
 			bf.Type = inferType(sf.Type)
 		}
 
@@ -109,6 +144,19 @@ func extractFields[T any](ctx context.Context, instance *T, validationErr *burro
 	}
 
 	return fields
+}
+
+// subformValue returns the struct reflect.Value to recurse into. A nil
+// pointer is replaced with a zero value of the pointee so the sub-fields
+// render as empty inputs instead of erroring out.
+func subformValue(fv reflect.Value) reflect.Value {
+	if fv.Kind() == reflect.Pointer {
+		if fv.IsNil() {
+			return reflect.New(fv.Type().Elem()).Elem()
+		}
+		return fv.Elem()
+	}
+	return fv
 }
 
 // fieldValue returns the value for template rendering, dereferencing pointers.

--- a/forms/field_test.go
+++ b/forms/field_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/oliverandrich/burrow"
 	"github.com/oliverandrich/burrow/i18n"
@@ -285,4 +286,133 @@ func TestExtractFieldsDoesNotMutateChoiceSource(t *testing.T) {
 
 	second := extractFields(ctx, instance, nil, dynamic, nil, nil)
 	assert.Equal(t, "Eintrag", findField(t, second, "Views").Choices[0].Label, "second call must translate from the original Label, not from the first call's output")
+}
+
+// Nested struct → subform tests.
+
+type formWithProfile struct { //nolint:govet // test fixture; field order matters for clarity
+	Title   string `form:"title" verbose:"Title"`
+	Profile struct {
+		Name string `form:"name" verbose:"Name" validate:"required"`
+		Bio  string `form:"bio" verbose:"Bio" widget:"textarea"`
+	} `form:"profile" verbose:"Profile" help_text:"About you"`
+}
+
+func TestExtractFieldsNestedStructAsSubform(t *testing.T) {
+	instance := &formWithProfile{Title: "x"}
+	instance.Profile.Name = "Alice"
+	instance.Profile.Bio = "hello"
+
+	fields := extractFields(noCtx, instance, nil, nil, nil, nil)
+
+	profile := findField(t, fields, "Profile")
+	assert.Equal(t, "subform", profile.Type, "struct-typed field must produce a subform")
+	assert.Equal(t, "profile", profile.FormName, "FormName uses the form tag, not the recursion-flattened name")
+	assert.Equal(t, "Profile", profile.Label)
+	assert.Equal(t, "About you", profile.HelpText)
+	require.Len(t, profile.SubFields, 2)
+
+	name := profile.SubFields[0]
+	assert.Equal(t, "Name", name.Name)
+	assert.Equal(t, "profile.name", name.FormName, "nested FormName follows the parent.child convention")
+	assert.Equal(t, "text", name.Type)
+	assert.Equal(t, "Alice", name.Value)
+	assert.True(t, name.Required, "nested validate:required must be detected")
+
+	bio := profile.SubFields[1]
+	assert.Equal(t, "textarea", bio.Type, "widget tag inside subform is honoured")
+}
+
+func TestExtractFieldsSubformSkippedByFormDash(t *testing.T) {
+	type formWithSkippedProfile struct {
+		Title   string `form:"title"`
+		Profile struct {
+			Name string `form:"name"`
+		} `form:"-"`
+	}
+	fields := extractFields(noCtx, &formWithSkippedProfile{}, nil, nil, nil, nil)
+	for _, bf := range fields {
+		require.NotEqual(t, "Profile", bf.Name, "form:\"-\" on a struct field must skip it entirely")
+	}
+}
+
+type profileForPointer struct {
+	Name string `form:"name" verbose:"Name"`
+}
+
+type formWithPointerProfile struct {
+	Title   string             `form:"title"`
+	Profile *profileForPointer `form:"profile" verbose:"Profile"`
+}
+
+func TestExtractFieldsSubformPointerToStruct(t *testing.T) {
+	t.Run("populated pointer", func(t *testing.T) {
+		instance := &formWithPointerProfile{Profile: &profileForPointer{Name: "Bob"}}
+		fields := extractFields(noCtx, instance, nil, nil, nil, nil)
+
+		profile := findField(t, fields, "Profile")
+		assert.Equal(t, "subform", profile.Type)
+		require.Len(t, profile.SubFields, 1)
+		assert.Equal(t, "Bob", profile.SubFields[0].Value)
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		instance := &formWithPointerProfile{Profile: nil}
+		fields := extractFields(noCtx, instance, nil, nil, nil, nil)
+
+		profile := findField(t, fields, "Profile")
+		assert.Equal(t, "subform", profile.Type, "nil pointer to struct still renders a subform with zero values")
+		require.Len(t, profile.SubFields, 1)
+		assert.Empty(t, profile.SubFields[0].Value, "nil pointer yields zero-value sub-field values")
+	})
+}
+
+func TestExtractFieldsTimeIsNotSubform(t *testing.T) {
+	type formWithTime struct {
+		Title     string    `form:"title"`
+		Published time.Time `form:"published" verbose:"Published"`
+	}
+	instance := &formWithTime{}
+	fields := extractFields(noCtx, instance, nil, nil, nil, nil)
+
+	published := findField(t, fields, "Published")
+	assert.Equal(t, "date", published.Type, "time.Time keeps the existing date type; no subform recursion")
+	assert.Empty(t, published.SubFields)
+}
+
+func TestExtractFieldsSubformOneLevelOnly(t *testing.T) {
+	type inner struct {
+		Detail string `form:"detail" verbose:"Detail"`
+	}
+	type outer struct {
+		Nested inner `form:"nested" verbose:"Nested"`
+	}
+	type root struct {
+		Outer outer `form:"outer" verbose:"Outer"`
+	}
+	fields := extractFields(noCtx, &root{}, nil, nil, nil, nil)
+
+	outerBF := findField(t, fields, "Outer")
+	require.Equal(t, "subform", outerBF.Type)
+	require.Len(t, outerBF.SubFields, 1)
+
+	nestedBF := outerBF.SubFields[0]
+	assert.Equal(t, "Nested", nestedBF.Name)
+	assert.Equal(t, "text", nestedBF.Type, "depth-2 struct field renders flat, not as another subform")
+	assert.Empty(t, nestedBF.SubFields, "subform recursion is one level only")
+}
+
+func TestExtractFieldsSubformValidationErrorRouting(t *testing.T) {
+	instance := &formWithProfile{}
+	ve := &burrow.ValidationError{
+		Errors: []burrow.FieldError{
+			{Field: "profile.name", Message: "name is required"},
+		},
+	}
+	fields := extractFields(noCtx, instance, ve, nil, nil, nil)
+
+	profile := findField(t, fields, "Profile")
+	require.Len(t, profile.SubFields, 2)
+	assert.Equal(t, []string{"name is required"}, profile.SubFields[0].Errors, "validation error on profile.name attaches to the nested BoundField")
+	assert.Empty(t, profile.SubFields[1].Errors)
 }

--- a/forms/tags.go
+++ b/forms/tags.go
@@ -67,9 +67,7 @@ func hasRequiredValidation(sf reflect.StructField) bool {
 
 // inferType maps a Go type to an HTML input type string.
 func inferType(t reflect.Type) string {
-	if t.Kind() == reflect.Pointer {
-		t = t.Elem()
-	}
+	t = derefType(t)
 	//nolint:exhaustive // only handle common form field types
 	switch t.Kind() {
 	case reflect.Bool:
@@ -91,4 +89,20 @@ func inferType(t reflect.Type) string {
 // isSkipped returns true if the field has form:"-".
 func isSkipped(sf reflect.StructField) bool {
 	return sf.Tag.Get("form") == "-"
+}
+
+// isSubformType reports whether t is a struct (or pointer to struct) that
+// should be rendered as a subform. time.Time is excluded — it has its own
+// "date" widget.
+func isSubformType(t reflect.Type) bool {
+	t = derefType(t)
+	return t.Kind() == reflect.Struct && t != reflect.TypeFor[time.Time]()
+}
+
+// derefType returns t.Elem() if t is a pointer type, else t.
+func derefType(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Pointer {
+		return t.Elem()
+	}
+	return t
 }


### PR DESCRIPTION
## Summary

Struct-typed form fields now render as subforms. `forms.extractFields` recurses one level into the nested struct and exposes its fields under the parent `BoundField.SubFields`. Nested `FormName` values follow the `parent.child` convention so `burrow.Bind` decodes them and validation errors route to the correct nested field.

First of three beans on the User-Profile pattern; this one stands alone and is useful for any document with nested struct fields (Address, Settings, Metadata, etc.).

## What changed

- `forms/field.go`: new `walkStructFields` helper handles the actual walking with a `formNamePrefix` and `allowSubforms` flag; `extractFields` delegates to it. Subform recursion is capped at one level — depth-2 structs render flat.
- `forms/tags.go`: new `isSubformType` (struct or pointer-to-struct, excluding `time.Time`) and `derefType` (shared with `inferType`).
- `BoundField` gains `SubFields []BoundField`, populated when `Type == "subform"`.
- Pointer-to-struct dereferenced; nil pointer yields a zero-value subform.
- `form:"-"` on the parent struct field skips the whole subform.
- `docs/guide/forms.md`: new "Nested struct fields (subforms)" section + the Example Template refactored into `myapp/form` + `myapp/field` with the subform branch.
- CHANGELOG entry under Unreleased Added.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 1518 passed
- [x] `golangci-lint run ./...` clean
- [x] New tests in `forms/field_test.go` cover: nested struct → subform, `form:"-"` skip, pointer-to-struct (populated + nil), `time.Time` exception, depth-2 limit (no further recursion), validation error routing via dotted FormName