### PR TITLE
test(i18n): guard contrib bundles against go-i18n reserved-key collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 ### Added
 
 - **`forms` package: nested-struct subform support.** Struct-typed form fields now render as **subforms** — `extractFields` recurses one level into the nested struct and exposes its fields under the parent's `BoundField.SubFields`. Nested `FormName` values follow the `parent.child` convention (e.g. `profile.name`) so `burrow.Bind` decodes them and validation errors route to the correct nested field. `time.Time` is excluded (keeps the `"date"` widget); pointer-to-struct is dereferenced (nil → zero-value sub-fields); recursion is capped at one level. Templates dispatch on `Type == "subform"` and iterate `.SubFields` — see [forms: Nested struct fields](guide/forms.md#nested-struct-fields-subforms).
+- **Translation guard test** (`TestTranslationsLoadInGoI18n`) loads every contrib's `active.*.toml` through a real go-i18n bundle, so reserved-key collisions (`id`, `hash`, `description`, `leftdelim`, `rightdelim`, plural keys) surface at test time instead of at server boot.
 
 ### Fixed
 

--- a/translations_consistency_test.go
+++ b/translations_consistency_test.go
@@ -2,13 +2,11 @@ package burrow_test
 
 import (
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/stretchr/testify/require"
 )
 
 // TestTranslationsHaveNoValueDivergentDuplicates walks every TOML translation
@@ -21,37 +19,21 @@ func TestTranslationsHaveNoValueDivergentDuplicates(t *testing.T) {
 	// locale -> key -> file -> raw scalar value
 	byLocale := map[string]map[string]map[string]string{}
 
-	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "site", "node_modules":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".toml") {
-			return nil
-		}
-		if !strings.Contains(filepath.ToSlash(path), "/translations/") {
-			return nil
-		}
-
+	forEachTranslationFile(t, func(fsys fs.FS, path string) {
 		locale := extractLocale(path)
 		if locale == "" {
-			return nil
+			return
 		}
 
-		raw, err := os.ReadFile(path)
+		raw, err := fs.ReadFile(fsys, path)
 		if err != nil {
-			return err
+			t.Errorf("%s: %v", path, err)
+			return
 		}
 		var decoded map[string]any
 		if _, err := toml.Decode(string(raw), &decoded); err != nil {
 			t.Errorf("%s: %v", path, err)
-			return nil
+			return
 		}
 
 		if byLocale[locale] == nil {
@@ -70,9 +52,7 @@ func TestTranslationsHaveNoValueDivergentDuplicates(t *testing.T) {
 			}
 			byLocale[locale][key][path] = s
 		}
-		return nil
 	})
-	require.NoError(t, err)
 
 	for locale, byKey := range byLocale {
 		for key, byFile := range byKey {

--- a/translations_reserved_keys_test.go
+++ b/translations_reserved_keys_test.go
@@ -1,0 +1,24 @@
+package burrow_test
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	i18nlib "github.com/nicksnyder/go-i18n/v2/i18n"
+	"golang.org/x/text/language"
+)
+
+// TestTranslationsLoadInGoI18n loads every contrib translation file through a
+// real go-i18n bundle to catch reserved top-level keys ("id", "hash",
+// "description", "leftdelim", "rightdelim", plural keys) that make go-i18n
+// reject the file at boot.
+func TestTranslationsLoadInGoI18n(t *testing.T) {
+	forEachTranslationFile(t, func(fsys fs.FS, path string) {
+		bundle := i18nlib.NewBundle(language.English)
+		bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
+		if _, err := bundle.LoadMessageFileFS(fsys, path); err != nil {
+			t.Errorf("%s: go-i18n rejected the bundle: %v", path, err)
+		}
+	})
+}

--- a/translations_test_helpers_test.go
+++ b/translations_test_helpers_test.go
@@ -1,0 +1,39 @@
+package burrow_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// forEachTranslationFile invokes fn for every active.*.toml shipped under a
+// "translations/" directory anywhere in the repo. Shared by the cross-contrib
+// translation guards so they stay aligned on the skip list and filters.
+func forEachTranslationFile(t *testing.T, fn func(fsys fs.FS, path string)) {
+	t.Helper()
+	repoFS := os.DirFS(".")
+	require.NoError(t, fs.WalkDir(repoFS, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "site", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".toml") {
+			return nil
+		}
+		if !strings.Contains(filepath.ToSlash(path), "/translations/") {
+			return nil
+		}
+		fn(repoFS, path)
+		return nil
+	}))
+}


### PR DESCRIPTION
## Summary

Loads every contrib `active.*.toml` through a real go-i18n bundle at test time so reserved top-level keys (`id`, `hash`, `description`, `leftdelim`, `rightdelim`, plural keys) surface in `go test ./...` instead of only at server boot. We hit exactly this class of bug in #33 — `ID = "ID"` in `contrib/jobs` blocked startup of every app registering jobs; without this guard the only signal was the runtime failure.

Pulls the file-enumeration loop out of `translations_consistency_test.go` into a shared `forEachTranslationFile` helper that both guards now use, so the skip list and `*/translations/active.*.toml` filter stay aligned.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 1523 passed (was 1522, +1 from the new guard)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Acceptance pin: temporarily reverting `"Job ID" = "Job ID"` to `ID = "ID"` makes the guard fail with `contrib/jobs/translations/active.en.toml: go-i18n rejected the bundle: reserved keys [ID] mixed with unreserved keys [...]` — exact boot-time message