### PR TITLE
feat(burrow): add --app-name flag with WebAuthn / SMTP / template consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ### Added
 
+- **`--app-name` global flag** (`APP_NAME` env, `server.app_name` toml) sets a human-readable application name available as `cfg.Config.Server.AppName`. Defaults to the binary basename (e.g. `notes`, `myapp`) so it's non-empty out of the box. Three consumers wired:
+    - **WebAuthn**: `--auth-webauthn-rp-display-name` loses its `"Web App"` default and falls back to `--app-name` when not set explicitly. The browser passkey dialog now reads "Save passkey for **Notes**" instead of "Save passkey for **Web App**" by default.
+    - **SMTP From**: a bare `--smtp-from=noreply@example.com` is decorated as `"Notes <noreply@example.com>"` automatically. Pre-formatted `--smtp-from="Acme <noreply@example.com>"` is left alone.
+    - **Template func**: `{{ appName }}` returns the configured name. Use it in layout titles, email subjects, footer copy, etc.
 - **`forms` package: nested-struct subform support.** Struct-typed form fields now render as **subforms** — `extractFields` recurses one level into the nested struct and exposes its fields under the parent's `BoundField.SubFields`. Nested `FormName` values follow the `parent.child` convention (e.g. `profile.name`) so `burrow.Bind` decodes them and validation errors route to the correct nested field. `time.Time` is excluded (keeps the `"date"` widget); pointer-to-struct is dereferenced (nil → zero-value sub-fields); recursion is capped at one level. Templates dispatch on `Type == "subform"` and iterate `.SubFields` — see [forms: Nested struct fields](guide/forms.md#nested-struct-fields-subforms).
 - **Translation guard test** (`TestTranslationsLoadInGoI18n`) loads every contrib's `active.*.toml` through a real go-i18n bundle, so reserved-key collisions (`id`, `hash`, `description`, `leftdelim`, `rightdelim`, plural keys) surface at test time instead of at server boot.
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package burrow
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -20,9 +22,23 @@ type ServerConfig struct {
 	Host            string
 	BaseURL         string
 	PIDFile         string
+	AppName         string
 	Port            int
 	MaxBodySize     int // in MB
 	ShutdownTimeout int // in seconds
+}
+
+// resolveAppName returns the explicit flag value when set, falling back to
+// the binary basename (os.Args[0]). It only returns "" when both the flag
+// and os.Args[0] are missing — a corner case in embedded contexts.
+func resolveAppName(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if len(os.Args) == 0 || os.Args[0] == "" {
+		return ""
+	}
+	return filepath.Base(os.Args[0])
 }
 
 // DatabaseConfig holds database settings.
@@ -64,6 +80,7 @@ func NewConfig(cmd *cli.Command) *Config {
 			Port:            int(cmd.Int("port")),
 			BaseURL:         cmd.String("base-url"),
 			PIDFile:         cmd.String("pid-file"),
+			AppName:         resolveAppName(cmd.String("app-name")),
 			MaxBodySize:     int(cmd.Int("max-body-size")),
 			ShutdownTimeout: int(cmd.Int("shutdown-timeout")),
 		},
@@ -191,6 +208,11 @@ func FlagSources(configSource func(key string) cli.ValueSource, envVar, tomlKey 
 // (e.g. a TOML file sourcer) for each flag.
 func CoreFlags(configSource func(key string) cli.ValueSource) []cli.Flag {
 	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "app-name",
+			Usage:   "Human-readable application name (used by WebAuthn dialogs, SMTP From-name, the {{ appName }} template func; defaults to the binary basename)",
+			Sources: FlagSources(configSource, "APP_NAME", "server.app_name"),
+		},
 		&cli.StringFlag{
 			Name:    "host",
 			Value:   "localhost",

--- a/config_test.go
+++ b/config_test.go
@@ -208,3 +208,13 @@ func TestConfigInAppConfig(t *testing.T) {
 	}
 	assert.Equal(t, "myhost", cfg.Config.Server.Host)
 }
+
+func TestResolveAppName_ExplicitFlagWins(t *testing.T) {
+	assert.Equal(t, "My App", resolveAppName("My App"))
+}
+
+func TestResolveAppName_FallsBackToBinaryBasename(t *testing.T) {
+	got := resolveAppName("")
+	assert.NotEmpty(t, got, "fallback should pick up the binary basename from os.Args[0]")
+	assert.NotContains(t, got, "/", "result should be a basename, not a full path")
+}

--- a/contrib/auth/app.go
+++ b/contrib/auth/app.go
@@ -172,10 +172,14 @@ func (a *App[P]) Configure(cfg *burrow.AppConfig, cmd *cli.Command) error {
 		rpOrigin = baseURL
 	}
 	rpID := resolveRPID(cmd.String("auth-webauthn-rp-id"), baseURL)
+	rpDisplayName := cmd.String("auth-webauthn-rp-display-name")
+	if rpDisplayName == "" && a.globalConfig != nil {
+		rpDisplayName = a.globalConfig.Server.AppName
+	}
 	waCtx, waCancel := context.WithCancel(context.Background())
 	waSvc, err := NewWebAuthnService(
 		waCtx,
-		cmd.String("auth-webauthn-rp-display-name"),
+		rpDisplayName,
 		rpID,
 		rpOrigin,
 	)
@@ -251,8 +255,7 @@ func (a *App[P]) Flags(configSource func(key string) cli.ValueSource) []cli.Flag
 		},
 		&cli.StringFlag{
 			Name:    "auth-webauthn-rp-display-name",
-			Value:   "Web App",
-			Usage:   "WebAuthn Relying Party display name",
+			Usage:   "WebAuthn Relying Party display name (override; defaults to --app-name)",
 			Sources: burrow.FlagSources(configSource, "WEBAUTHN_RP_DISPLAY_NAME", "auth.webauthn_rp_display_name"),
 		},
 		&cli.StringFlag{

--- a/contrib/authmail/smtpmail/app.go
+++ b/contrib/authmail/smtpmail/app.go
@@ -1,10 +1,28 @@
 package smtpmail
 
 import (
+	"fmt"
+	"net/mail"
+
 	"github.com/oliverandrich/burrow"
 	"github.com/oliverandrich/burrow/contrib/authmail"
 	"github.com/urfave/cli/v3"
 )
+
+// decorateFrom prefixes a bare SMTP From address with appName so the
+// rendered "From" header reads "AppName <user@example.com>" instead of a
+// raw address. If from is already in "Name <addr>" form (parsed name
+// non-empty) or is unparseable, the input is returned unchanged.
+func decorateFrom(from, appName string) string {
+	if appName == "" || from == "" {
+		return from
+	}
+	addr, err := mail.ParseAddress(from)
+	if err != nil || addr == nil || addr.Name != "" {
+		return from
+	}
+	return fmt.Sprintf("%s <%s>", appName, addr.Address)
+}
 
 // App implements the authmail SMTP contrib app.
 type App struct {
@@ -72,13 +90,17 @@ func (a *App) Flags(configSource func(key string) cli.ValueSource) []cli.Flag {
 	}
 }
 
-func (a *App) Configure(_ *burrow.AppConfig, cmd *cli.Command) error {
+func (a *App) Configure(cfg *burrow.AppConfig, cmd *cli.Command) error {
+	from := cmd.String("smtp-from")
+	if cfg != nil && cfg.Config != nil {
+		from = decorateFrom(from, cfg.Config.Server.AppName)
+	}
 	config := SMTPConfig{
 		Host:     cmd.String("smtp-host"),
 		Port:     int(cmd.Int("smtp-port")),
 		Username: cmd.String("smtp-username"),
 		Password: cmd.String("smtp-password"),
-		From:     cmd.String("smtp-from"),
+		From:     from,
 		TLS:      cmd.String("smtp-tls"),
 	}
 

--- a/contrib/authmail/smtpmail/app_test.go
+++ b/contrib/authmail/smtpmail/app_test.go
@@ -89,3 +89,23 @@ func TestConfigureWithCustomFlags(t *testing.T) {
 	assert.Equal(t, "noreply@example.com", m.config.From)
 	assert.Equal(t, "tls", m.config.TLS)
 }
+
+func TestDecorateFrom_BareEmailGetsDecorated(t *testing.T) {
+	assert.Equal(t, "Notes <noreply@example.com>", decorateFrom("noreply@example.com", "Notes"))
+}
+
+func TestDecorateFrom_AlreadyDecoratedStaysAlone(t *testing.T) {
+	assert.Equal(t, "Acme <noreply@example.com>", decorateFrom("Acme <noreply@example.com>", "Notes"))
+}
+
+func TestDecorateFrom_EmptyAppNamePassThrough(t *testing.T) {
+	assert.Equal(t, "noreply@example.com", decorateFrom("noreply@example.com", ""))
+}
+
+func TestDecorateFrom_EmptyFromPassThrough(t *testing.T) {
+	assert.Empty(t, decorateFrom("", "Notes"))
+}
+
+func TestDecorateFrom_UnparseableFromPassThrough(t *testing.T) {
+	assert.Equal(t, "not an address", decorateFrom("not an address", "Notes"))
+}

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -319,8 +319,8 @@ The auth app implements `HasAdmin` to provide user and invite management in the 
 | `--auth-use-email` | `AUTH_USE_EMAIL` | `false` | Use email instead of username |
 | `--auth-require-verification` | `AUTH_REQUIRE_VERIFICATION` | `false` | Require email verification |
 | `--auth-invite-only` | `AUTH_INVITE_ONLY` | `false` | Require invite to register |
-| `--auth-webauthn-rp-id` | `WEBAUTHN_RP_ID` | `localhost` | WebAuthn Relying Party ID (domain) |
-| `--auth-webauthn-rp-display-name` | `WEBAUTHN_RP_DISPLAY_NAME` | `Web App` | WebAuthn RP display name |
+| `--auth-webauthn-rp-id` | `WEBAUTHN_RP_ID` | (URL host) | WebAuthn Relying Party ID; falls back to the host of `--base-url` |
+| `--auth-webauthn-rp-display-name` | `WEBAUTHN_RP_DISPLAY_NAME` | (`--app-name`) | Display name shown in the browser passkey dialog. Falls back to the global `--app-name` (binary basename by default), so most apps don't set this explicitly. |
 | `--auth-webauthn-rp-origin` | `WEBAUTHN_RP_ORIGIN` | (base URL) | WebAuthn RP origin |
 
 ## Email Service

--- a/docs/contrib/authmail.md
+++ b/docs/contrib/authmail.md
@@ -104,7 +104,7 @@ mailer.SendInvite(ctx, "bob@example.com", "https://example.com/auth/register?inv
 | `--smtp-port` | `SMTP_PORT` | `587` | SMTP server port |
 | `--smtp-username` | `SMTP_USERNAME` | (none) | SMTP username |
 | `--smtp-password` | `SMTP_PASSWORD` | (none) | SMTP password |
-| `--smtp-from` | `SMTP_FROM` | `noreply@localhost` | Sender email address |
+| `--smtp-from` | `SMTP_FROM` | `noreply@localhost` | Sender email address. A bare address is decorated with the global `--app-name` automatically (`Notes <noreply@example.com>`); pre-formatted `"Name <addr>"` values pass through unchanged. |
 | `--smtp-tls` | `SMTP_TLS` | `starttls` | TLS mode: `starttls`, `tls`, or `none` |
 
 ### TLS Modes

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -11,6 +11,7 @@ Complete list of all configuration flags, environment variables, and TOML keys.
 | `--host` | `HOST` | `server.host` | `localhost` | Host to bind to |
 | `--port` | `PORT` | `server.port` | `8080` | Port to listen on |
 | `--base-url` | `BASE_URL` | `server.base_url` | (auto-resolved) | Base URL for the application |
+| `--app-name` | `APP_NAME` | `server.app_name` | (binary basename) | Human-readable application name. Surfaces in WebAuthn passkey dialogs, SMTP `From`-name decoration, and the `{{ appName }}` template func. |
 | `--max-body-size` | `MAX_BODY_SIZE` | `server.max_body_size` | `1` | Maximum request body size in MB |
 | `--shutdown-timeout` | `SHUTDOWN_TIMEOUT` | `server.shutdown_timeout` | `10` | Graceful shutdown timeout in seconds |
 | `--pid-file` | `PID_FILE` | `server.pid_file` | (none) | Path to PID file (for systemd/supervisor) |
@@ -67,8 +68,8 @@ No flags. Supported locales are derived from each app's `HasTranslations.Transla
 | `--auth-use-email` | `AUTH_USE_EMAIL` | `false` | Use email instead of username |
 | `--auth-require-verification` | `AUTH_REQUIRE_VERIFICATION` | `false` | Require email verification before login |
 | `--auth-invite-only` | `AUTH_INVITE_ONLY` | `false` | Require invite to register |
-| `--auth-webauthn-rp-id` | `WEBAUTHN_RP_ID` | `localhost` | WebAuthn Relying Party ID (domain name) |
-| `--auth-webauthn-rp-display-name` | `WEBAUTHN_RP_DISPLAY_NAME` | `Web App` | WebAuthn RP display name |
+| `--auth-webauthn-rp-id` | `WEBAUTHN_RP_ID` | (URL host) | WebAuthn Relying Party ID; falls back to the host of `--base-url` |
+| `--auth-webauthn-rp-display-name` | `WEBAUTHN_RP_DISPLAY_NAME` | (`--app-name`) | WebAuthn RP display name; falls back to `--app-name` (binary basename) when unset |
 | `--auth-webauthn-rp-origin` | `WEBAUTHN_RP_ORIGIN` | (base URL) | WebAuthn RP origin |
 
 ### Jobs

--- a/docs/reference/template-functions.md
+++ b/docs/reference/template-functions.md
@@ -23,6 +23,7 @@ Provided by the framework itself. Always available.
 | `mediaURL` | `{{ mediaURL .Hero }}` | Returns the public URL for a `document.Attachment`. Auto-registered when Den is opened with `den.WithStorage(...)`; unregistered (and a parse-time error) when no Storage is configured. |
 | `icon` | `{{ icon "auth/icon_people" }}` | Looks up the named template define and returns its rendered HTML. Returns empty when the name is empty or unknown. Used by layouts to render `NavItem.Icon` / `NavLink.Icon` / `admin.DashboardItem.Icon` (all hold template-define names). See [Navigation › Icon convention](../guide/navigation.md#icon-convention). |
 | `dict` | `{{ template "x" (dict "Page" .Page "BasePath" "/x") }}` | Builds a `map[string]any` from alternating key/value pairs. Useful for passing multiple values to a sub-template. Keys must be strings. |
+| `appName` | `<title>{{ appName }}</title>` | The configured application name (from `--app-name`, env `APP_NAME`, toml `server.app_name`; defaults to the binary basename). Same source feeds WebAuthn passkey dialogs and SMTP `From`-name decoration. |
 
 **Navigation (request-scoped, provided by the framework):**
 

--- a/templates.go
+++ b/templates.go
@@ -164,6 +164,15 @@ func (s *Server) collectFuncMap() (template.FuncMap, []fs.FS) {
 		}
 		return template.HTML(buf.String()) //nolint:gosec // template output, contextually escaped
 	}
+	// appName returns the configured human-readable application name (from
+	// --app-name or the binary basename). Static across the process lifetime,
+	// so it lives in the boot-time FuncMap rather than per-request.
+	funcMap["appName"] = func() string {
+		if s.appCfg == nil || s.appCfg.Config == nil {
+			return ""
+		}
+		return s.appCfg.Config.Server.AppName
+	}
 	baseKeys := make(map[string]bool, len(funcMap))
 	for k := range funcMap {
 		baseKeys[k] = true


### PR DESCRIPTION
## Summary

A new global `--app-name` flag (`APP_NAME` env, `server.app_name` toml) names the application for human-facing surfaces. Defaults to the binary basename (`notes`, `myapp`, …) so apps get a non-empty value with no configuration. Three consumers wired:

- **WebAuthn passkey dialog**: `--auth-webauthn-rp-display-name` loses its `"Web App"` default and falls back to `--app-name`. The browser now shows "Save passkey for **Notes**" by default instead of "Save passkey for **Web App**".
- **SMTP From-Name**: a bare `--smtp-from=noreply@example.com` is decorated as `"Notes <noreply@example.com>"` automatically. Pre-formatted `"Acme <noreply@example.com>"` input passes through unchanged (detected via `net/mail.ParseAddress`).
- **Template func `{{ appName }}`**: usable in layouts, email subjects, footer copy, etc.

No breaking change. Apps that explicitly set the override flags continue to work as-is; the only behaviour shift is the default-case improvement for `--auth-webauthn-rp-display-name`.

## What's in here

- `config.go`: new `Server.AppName` field, new `--app-name` flag, new `resolveAppName(flagValue)` helper (`filepath.Base(os.Args[0])` fallback). `NewConfig` populates `AppName` non-empty.
- `templates.go`: `appName` injected into the boot-time FuncMap inside `collectFuncMap` (alongside `icon`). Static across process lifetime, lives in the base FuncMap rather than per-request.
- `contrib/auth/app.go`: `auth-webauthn-rp-display-name` loses `Value: "Web App"`. Configure reads the flag; on empty, falls back to `cfg.Config.Server.AppName`.
- `contrib/authmail/smtpmail/app.go`: new unexported `decorateFrom(from, appName)`. Configure decorates when AppName is set and the From address is bare.
- Tests: 2 `TestResolveAppName_*` and 5 `TestDecorateFrom_*`.
- Docs: `docs/reference/configuration.md`, `docs/reference/template-functions.md`, `docs/contrib/auth.md`, `docs/contrib/authmail.md` — flag tables and the appName section. CHANGELOG entry under Unreleased › Added.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 1536 passed (+7 new: 2 resolveAppName, 5 decorateFrom)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go run ./example/notes/cmd/server -h | grep app-name` shows the new flag with the binary-basename fallback note
- [x] Existing pure-flag SMTP tests still pass (`Configure(nil, cmd)` is guarded for callers without an AppConfig)