### PR TITLE
fix(auth): auto-regenerate recovery codes on last-code consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- **`contrib/auth` recovery flow auto-regenerates on last-code consumption.** When `RecoveryLogin` consumes the user's final unused code, the handler now routes through the `/auth/recovery-codes` ack flow so passkey-only accounts can't end up at `remaining_codes: 0` without a fresh safety net. Happy path with `remaining > 0` is unchanged.
+
 ## 0.22.0 — 2026-05-20
 
 > **Migrating from v0.21.x?** See the [v0.22 migration guide](migration/v0.22.md) for the concrete before/after patterns.

--- a/contrib/auth/handlers_recovery.go
+++ b/contrib/auth/handlers_recovery.go
@@ -63,7 +63,29 @@ func (a *App[P]) RecoveryLogin(w http.ResponseWriter, r *http.Request) error {
 		return errorJSONLog(w, http.StatusInternalServerError, "failed to create session", err)
 	}
 
-	remaining, _ := a.repo.GetUnusedRecoveryCodeCount(r.Context(), user.ID)
+	remaining, err := a.repo.GetUnusedRecoveryCodeCount(r.Context(), user.ID)
+	if err != nil {
+		return errorJSONLog(w, http.StatusInternalServerError, "failed to count recovery codes", err)
+	}
+
+	if remaining == 0 {
+		// Last code was just consumed — regenerate and route through the
+		// ack flow so the user cannot proceed without a fresh safety net.
+		codes, err := a.generateAndStoreRecoveryCodes(r.Context(), user.ID)
+		if err != nil {
+			return errorJSONLog(w, http.StatusInternalServerError, "failed to regenerate codes", err)
+		}
+		if err := session.Set(w, r, "recovery_codes", codes); err != nil {
+			return errorJSONLog(w, http.StatusInternalServerError, "failed to store recovery codes", err)
+		}
+		if err := session.Set(w, r, "redirect_after_login", redirect); err != nil {
+			return errorJSONLog(w, http.StatusInternalServerError, "failed to store redirect", err)
+		}
+		return burrow.JSON(w, http.StatusOK, map[string]any{
+			"status":   "ok",
+			"redirect": "/auth/recovery-codes",
+		})
+	}
 
 	return burrow.JSON(w, http.StatusOK, map[string]any{
 		"status":          "ok",

--- a/contrib/auth/handlers_test.go
+++ b/contrib/auth/handlers_test.go
@@ -830,6 +830,97 @@ func TestRecoveryLoginSuccess(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "remaining_codes")
 }
 
+func TestRecoveryLoginLastCodeTriggersRegenerate(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	user, _ := repo.CreateUser(context.Background(), "alice")
+
+	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
+	codes, hashes, err := svc.GenerateCodes(CodeCount)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateRecoveryCodes(context.Background(), user.ID, hashes[:1]))
+	consumedCode := codes[0]
+
+	body := strings.NewReader(`{"username":"alice","code":"` + consumedCode + `"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithSession(req, nil)
+	rec := httptest.NewRecorder()
+
+	err = h.RecoveryLogin(rec, req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"redirect":"/auth/recovery-codes"`)
+	assert.NotContains(t, rec.Body.String(), "remaining_codes")
+
+	values := session.GetValues(req)
+	require.NotNil(t, values)
+	assert.Equal(t, user.ID, values["user_id"])
+	storedCodes, ok := values["recovery_codes"].([]string)
+	require.True(t, ok, "expected recovery_codes in session")
+	assert.Len(t, storedCodes, CodeCount)
+	assert.NotContains(t, storedCodes, consumedCode, "regenerated codes must differ from the consumed one")
+	assert.Equal(t, h.config.LoginRedirect, values["redirect_after_login"])
+
+	freshCodes, err := repo.GetUnusedRecoveryCodes(context.Background(), user.ID)
+	require.NoError(t, err)
+	assert.Len(t, freshCodes, CodeCount)
+}
+
+func TestRecoveryLoginPenultimateCodeKeepsHappyPath(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	user, _ := repo.CreateUser(context.Background(), "alice")
+
+	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
+	codes, hashes, err := svc.GenerateCodes(CodeCount)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateRecoveryCodes(context.Background(), user.ID, hashes[:2]))
+
+	body := strings.NewReader(`{"username":"alice","code":"` + codes[0] + `"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithSession(req, nil)
+	rec := httptest.NewRecorder()
+
+	err = h.RecoveryLogin(rec, req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"remaining_codes":1`)
+	assert.Contains(t, rec.Body.String(), `"redirect":"`+h.config.LoginRedirect+`"`)
+
+	values := session.GetValues(req)
+	require.NotNil(t, values)
+	assert.Equal(t, user.ID, values["user_id"])
+	_, hasCodes := values["recovery_codes"]
+	assert.False(t, hasCodes, "session must not stash recovery_codes on happy path")
+	_, hasRedirect := values["redirect_after_login"]
+	assert.False(t, hasRedirect, "session must not stash redirect_after_login on happy path")
+}
+
+func TestRecoveryLoginLastCodePreservesSessionRedirect(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	user, _ := repo.CreateUser(context.Background(), "alice")
+
+	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
+	codes, hashes, err := svc.GenerateCodes(CodeCount)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateRecoveryCodes(context.Background(), user.ID, hashes[:1]))
+
+	body := strings.NewReader(`{"username":"alice","code":"` + codes[0] + `"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = session.Inject(req, map[string]any{"redirect_after_login": "/custom-page"})
+	rec := httptest.NewRecorder()
+
+	err = h.RecoveryLogin(rec, req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"redirect":"/auth/recovery-codes"`)
+
+	values := session.GetValues(req)
+	require.NotNil(t, values)
+	assert.Equal(t, "/custom-page", values["redirect_after_login"], "original redirect target must survive the regenerate")
+}
+
 // --- RegenerateRecoveryCodes tests ---
 
 func TestRegenerateRecoveryCodes(t *testing.T) {

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -133,6 +133,8 @@ All routes are registered under `/auth`:
 | GET | `/auth/verify-email` | Verify email via token |
 | POST | `/auth/resend-verification` | Resend verification email |
 
+When `POST /auth/recovery` consumes the user's final unused recovery code, the handler auto-regenerates a fresh set and redirects to `/auth/recovery-codes` (the same ack flow as `POST /auth/recovery-codes/regenerate`), so a passkey-only account never reaches a "logged in with zero codes left" state.
+
 Admin routes (registered via `HasAdmin`, require auth + admin role):
 
 | Method | Path | Description |


### PR DESCRIPTION
## Summary

- `contrib/auth/RecoveryLogin` now routes through the `/auth/recovery-codes` ack flow when the user consumes their final unused recovery code — same session-stash shape (`recovery_codes`, `redirect_after_login`) and same destination as `RegenerateRecoveryCodes`.
- Passkey-only accounts can no longer reach `remaining_codes: 0` without a fresh safety net.
- Happy path with `remaining > 0` is unchanged; clients consuming `remaining_codes` keep working.
- The `GetUnusedRecoveryCodeCount` error is now propagated instead of silently discarded, since it controls the branch.

Discovered while wiring `contrib/auth` into a downstream consumer where the obvious client-side workaround (middleware checking the count on every request) was a layering violation — all the primitives live here.

## Test plan

- [x] `go test ./contrib/auth/` — 318 passed, 0 failed
- [x] `golangci-lint run ./...` — 0 issues
- [x] `mise run docs-build` — no warnings
- [x] New tests: `TestRecoveryLoginLastCodeTriggersRegenerate`, `TestRecoveryLoginPenultimateCodeKeepsHappyPath`, `TestRecoveryLoginLastCodePreservesSessionRedirect`
- [x] Existing 11 `TestRecoveryLogin*` tests still green