### PR TITLE
docs: correct contrib/jobs as "Den-backed" not "SQLite-backed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 - **`docs/guide/inter-app-communication.md` documents three lookup patterns** — Hard-Dependency, Optional-Service, Soft-Discovery — with the registry function each one uses and the failure mode it carries.
 - **`sse.BrokerFromRegistry` simplified to `registry.Get[*App]`.** Behaviour unchanged (still returns nil when SSE is not registered); the old name-lookup-plus-type-assert is gone.
+- **`contrib/jobs` docs corrected to "Den-backed (SQLite + Postgres)".** Doc comments and READMEs called it "SQLite-backed" — that was true in v0.1 but the repository has been Postgres-aware since Den arrived. Code behaviour unchanged.
 
 ## 0.23.0 — 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ contrib/        Reusable apps
   healthcheck/  Liveness and readiness probes
   htmx/         htmx static asset + request/response helpers
   i18n/         Locale detection and translations
-  jobs/         SQLite-backed background job queue
+  jobs/         Den-backed background job queue (SQLite + Postgres)
   messages/     Flash messages
   ratelimit/    Per-client rate limiting
   session/      Cookie-based sessions

--- a/burrow.go
+++ b/burrow.go
@@ -125,7 +125,7 @@
 //   - i18n — locale detection and translations (go-i18n)
 //   - admin — admin panel with generic CRUD via ModelAdmin
 //   - htmx — HTMX asset serving and request/response helpers
-//   - jobs — SQLite-backed in-process job queue with retry
+//   - jobs — Den-backed in-process job queue with retry (SQLite + Postgres)
 //   - sse — Server-Sent Events with in-memory pub/sub broker
 //   - uploads — pluggable file upload storage
 //   - messages — flash messages via session storage

--- a/docs/contrib/jobs.md
+++ b/docs/contrib/jobs.md
@@ -1,6 +1,6 @@
 # Jobs
 
-In-process, SQLite-backed background job queue with a worker pool, retry logic, and admin UI.
+In-process, Den-backed background job queue with a worker pool, retry logic, and admin UI. Runs on SQLite or Postgres, optionally against a database separate from the application's shared DB.
 
 **Package:** `github.com/oliverandrich/burrow/contrib/jobs`
 

--- a/queue.go
+++ b/queue.go
@@ -40,7 +40,9 @@ type Enqueuer interface {
 }
 
 // Queue provides job handler registration, enqueueing, and cancellation.
-// contrib/jobs provides a SQLite-backed implementation.
+// contrib/jobs provides a Den-backed implementation that works on both
+// SQLite and Postgres, and optionally against a database separate from
+// the application's shared DB (see the jobs-database-dsn flag).
 type Queue interface {
 	Enqueuer
 	Handle(typeName string, fn JobHandlerFunc, opts ...JobOption)


### PR DESCRIPTION
## Summary

`contrib/jobs` has been Postgres-aware since the Den ODM landed — `repository.go` uses `den.NewQuery`, `den.RunInTransaction`, and `FOR UPDATE SKIP LOCKED` semantics that Den routes to both SQLite (`BEGIN IMMEDIATE` serialisation) and Postgres (native `FOR UPDATE SKIP LOCKED`). The doc comments and READMEs still called it "SQLite-backed" — that was accurate in v0.1 but stuck through five rewrites.

Surfaced while researching whether `package burrow`'s task/queue types could move to `contrib/jobs` (they can't, see PR #45 discussion, but the wrong description got noticed in the process).

## Changes

- `queue.go` — doc comment updated: "Den-backed implementation that works on both SQLite and Postgres, and optionally against a database separate from the application's shared DB"
- `burrow.go` — package doc's contrib list
- `README.md` — contrib directory tree
- `docs/contrib/jobs.md` — intro paragraph
- `CHANGELOG.md` — entry under Changed in Unreleased

No code behaviour changes.

## Test plan

- [ ] CI green: `test (1.26)`, `lint`, `Audit workflows (zizmor)`
- [ ] `mise run docs-build` clean locally