### PR TITLE
fix(ci): bump golangci-lint-action pin to current v9 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           go-version: '1.26'
           cache: false
 
-      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
## Summary

- Closes https://github.com/oliverandrich/burrow/security/code-scanning/7
- zizmor `ref-version-mismatch`: the `v9` tag has moved from v9.2.0 (`1e7e51e7...`) to v9.2.1 (`82606bf2...`); bump the pinned SHA so the `# v9` comment stays honest

## Test plan

- [ ] PR CI passes (lint job uses the bumped action)
- [ ] zizmor code-scanning alert #7 auto-closes after merge