### PR TITLE
feat(mise): add clean and clean-all tasks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -37,6 +37,24 @@ run = "govulncheck ./..."
 description = "List active beans (excludes completed and scrapped)"
 run = "beans list --no-status completed --no-status scrapped"
 
+[tasks.clean]
+description = "Remove build artifacts and generated files"
+run = [
+    "rm -rf bin tmp site",
+    "rm -f coverage.out coverage.html",
+    "rm -f docs/llms-full.txt docs/changelog.md docs/third-party-licenses.md",
+    "find . -type d -name .tailwind -not -path './.git/*' -prune -exec rm -rf {} + 2>/dev/null || true",
+    "find example -type f -path '*/static/*' ! -name .gitkeep -delete 2>/dev/null || true",
+]
+
+[tasks."clean-all"]
+description = "Like clean, plus local runtime data dirs and SQLite files anywhere in the tree"
+depends = ["clean"]
+run = [
+    "find . -type d -name data -not -path './.git/*' -prune -exec rm -rf {} + 2>/dev/null || true",
+    "find . -type f \\( -name '*.db' -o -name '*.db-shm' -o -name '*.db-wal' \\) -not -path './.git/*' -delete 2>/dev/null || true",
+]
+
 [tasks."example-hello"]
 description = "Run the hello world example (builds Tailwind CSS first)"
 run = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- **`mise run clean` and `mise run clean-all` tasks** in burrow itself and the project scaffold. `clean` removes build artifacts and generated files (coverage outputs, `bin/`, `tmp/`, `site/`, docs build output, `.tailwind/` source dirs, generated example static bundles); `clean-all` additionally wipes every gitignored `data/` runtime dir and every `*.db*` SQLite file anywhere in the tree. `clean-all` depends on `clean` so there's no copy-paste drift.
+
 ## 0.25.2 — 2026-05-24
 
 ### Changed

--- a/cmd/burrow/templates/project/.mise.toml
+++ b/cmd/burrow/templates/project/.mise.toml
@@ -43,6 +43,23 @@ run = [
 description = "Tidy module dependencies"
 run = "go mod tidy"
 
+[tasks.clean]
+description = "Remove build artifacts and generated files"
+run = [
+    "rm -rf build dist .tailwind",
+    "rm -f coverage.out coverage.html",
+    "rm -f internal/app/static/app.min.css",
+    "find . -maxdepth 2 -type f -name '*.coverprofile' -delete 2>/dev/null || true",
+]
+
+[tasks."clean-all"]
+description = "Like clean, plus local runtime data dir and SQLite files (NOT .env)"
+depends = ["clean"]
+run = [
+    "rm -rf data",
+    "find . -type f \\( -name '*.db' -o -name '*.db-shm' -o -name '*.db-wal' \\) -not -path './.git/*' -delete 2>/dev/null || true",
+]
+
 [tasks.vuln]
 description = "Run vulnerability check"
 run = "govulncheck ./..."


### PR DESCRIPTION
## Summary

- `mise run clean` removes build artifacts and generated files: `bin/`, `tmp/`, `site/`, coverage outputs, docs build outputs, every `.tailwind/` source dir, generated example static bundles.
- `mise run clean-all` (depends on `clean`) additionally wipes every gitignored `data/` runtime dir and every `*.db*` SQLite file anywhere in the tree.
- Same pair lands in the project scaffold (`cmd/burrow/templates/project/.mise.toml`) so newly-generated projects get them too.

Both tasks use `find -prune … -exec` / `find … -delete` with `-not -path './.git/*'` so the patterns catch artifacts at any depth (tutorial step DBs at depth 4, `.tailwind/` dirs under `example/{hello,notes}/`, `data/` under `server/`, `contrib/auth/`, `tutorial/step*/`, `example/notes/`) without descending into `.git/`.

## Test plan

- [x] `mise run clean` in burrow root removes `coverage.{out,html}`, `site/`, both `example/{hello,notes}/.tailwind/`, generated example static bundles (`.gitkeep` files preserved)
- [x] `mise run clean-all` dry-find covers all 7 `data/` dirs and all 12 `*.db*` files in burrow
- [x] Default DSN in the scaffold (`sqlite:///data/app.db`) matches what scaffold `clean-all` wipes