### PR TITLE
fix(dev): ignore stale exit observations in monitorAppExits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 - **`mise run clean` and `mise run clean-all` tasks** in burrow itself and the project scaffold. `clean` removes build artifacts and generated files (coverage outputs, `bin/`, `tmp/`, `site/`, docs build output, `.tailwind/` source dirs, generated example static bundles); `clean-all` additionally wipes every gitignored `data/` runtime dir and every `*.db*` SQLite file anywhere in the tree. `clean-all` depends on `clean` so there's no copy-paste drift.
 - **`docs/getting-started/scaffold.md`** documents the output of `burrow new` — annotated file tree, full mise-task reference, dev/release loops, and what the scaffold deliberately omits. The Quick Start tip box, the index Minimal Example, and the Tooling CLI section now cross-link to it; `tooling.md` keeps the CLI-flag reference, the new page covers the generated project.
 
+### Fixed
+
+- **`burrow dev` no longer kills a freshly-restarted child on a stale exit observation.** When the app exited (compile error, panic) and the user saved a file before the supervisor's exit-monitor goroutine had finished its cleanup, the cleanup would cancel the brand-new child's context, killing it. The dev server recovered on the next save but the experience looked like "save → crash → nothing rebuilds." The exit handler now refuses to act on observations from a previous generation (`internal/dev/supervisor.go`).
+
 ## 0.25.2 — 2026-05-24
 
 ### Changed

--- a/internal/dev/dev.go
+++ b/internal/dev/dev.go
@@ -148,7 +148,13 @@ func monitorAppExits(ctx context.Context, s *supervisor, log io.Writer) {
 		case <-ctx.Done():
 			return
 		case <-exited:
-			err := s.clearExited()
+			did, err := s.handleUnsolicitedExit(exited)
+			if !did {
+				// A Restart raced ahead while we were unblocking. The
+				// fresh child is the supervisor's current concern; do
+				// not log over its start or touch its lifecycle.
+				continue
+			}
 			// Skip the log if shutdown is in flight — the exit was
 			// almost certainly our own SIGTERM and the user has
 			// already seen `burrow dev: shutting down`.

--- a/internal/dev/supervisor.go
+++ b/internal/dev/supervisor.go
@@ -65,13 +65,24 @@ func (s *supervisor) currentExitedChan() (<-chan struct{}, bool) {
 	return s.exited, true
 }
 
-// clearExited resets the supervisor state after an unsolicited exit
-// observed via currentExitedChan. Returns the exit error captured by
-// the Wait goroutine (nil for clean exit). Safe to call when no child
-// is or was running — returns nil.
-func (s *supervisor) clearExited() error {
+// handleUnsolicitedExit resets the supervisor state after an unsolicited
+// exit observed via currentExitedChan, but only when the observed
+// channel still matches the supervisor's current generation. The bool
+// return signals whether the cleanup actually ran: when it is false the
+// caller observed a stale generation (a Restart raced ahead while the
+// observer was unblocking) and must NOT log or otherwise act on this
+// event — the fresh child belongs to the supervisor's current state and
+// is still the user's concern. The error is the value captured by the
+// Wait goroutine (nil for clean exit) and is only meaningful when the
+// bool is true.
+func (s *supervisor) handleUnsolicitedExit(observed <-chan struct{}) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.exited != observed {
+		// A Restart raced ahead and installed a new generation.
+		// Touching s.cancel here would kill the freshly-started child.
+		return false, nil
+	}
 	err := s.exitErr
 	if s.cancel != nil {
 		s.cancel()
@@ -80,7 +91,7 @@ func (s *supervisor) clearExited() error {
 	s.exited = nil
 	s.cancel = nil
 	s.exitErr = nil
-	return err
+	return true, err
 }
 
 // Start launches the configured command. It is an error to call

--- a/internal/dev/supervisor_test.go
+++ b/internal/dev/supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -62,6 +63,85 @@ func TestSupervisor_StopWhenAlreadyExited(t *testing.T) {
 	// `true` exits ~immediately — Stop must be a safe no-op.
 	time.Sleep(50 * time.Millisecond)
 	require.NoError(t, s.Stop())
+}
+
+// TestSupervisor_HandleUnsolicitedExit_IgnoresStaleObservation pins the
+// fix for the monitorAppExits race: when an exit observation lands after
+// a Restart has already installed a fresh generation, the late observer
+// must NOT cancel the new child.
+func TestSupervisor_HandleUnsolicitedExit_IgnoresStaleObservation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("supervisor signal handling is Linux-tested only")
+	}
+	sleep, err := exec.LookPath("sleep")
+	require.NoError(t, err)
+
+	cfg := Config{KillTimeout: 500 * time.Millisecond}
+	s := newSupervisor(t.Context(), "test", "", os.Environ(), cfg, sleep, "60")
+	require.NoError(t, s.Start())
+
+	firstPID := s.PID()
+	firstExited, ok := s.currentExitedChan()
+	require.True(t, ok)
+
+	// Kill the first child outside the supervisor and wait for the Wait
+	// goroutine to close its exited channel — this is the moment
+	// monitorAppExits would normally unblock and start the cleanup.
+	require.NoError(t, syscall.Kill(firstPID, syscall.SIGKILL))
+	<-firstExited
+
+	// A Restart races ahead before the (still-blocked) cleanup runs:
+	// Stop is a no-op against the dead state but resets the slots, then
+	// Start installs a fresh generation.
+	require.NoError(t, s.Restart())
+	secondPID := s.PID()
+	secondExited, ok := s.currentExitedChan()
+	require.True(t, ok)
+	require.NotEqual(t, firstPID, secondPID, "Restart must produce a new PID")
+
+	// Now the late observer wakes up holding the OLD exited channel.
+	did, err := s.handleUnsolicitedExit(firstExited)
+	require.NoError(t, err)
+	assert.False(t, did, "stale observation must not act on the current generation")
+
+	// The fresh child is untouched.
+	assert.Equal(t, secondPID, s.PID(), "fresh child must still be the registered process")
+	select {
+	case <-secondExited:
+		t.Fatal("fresh child was killed by the stale-observation handler")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, s.Stop())
+}
+
+// TestSupervisor_HandleUnsolicitedExit_ActsOnCurrentObservation covers
+// the happy path: when the observed exited channel still matches the
+// supervisor's current generation, cleanup runs and state is cleared.
+func TestSupervisor_HandleUnsolicitedExit_ActsOnCurrentObservation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("supervisor signal handling is Linux-tested only")
+	}
+	sleep, err := exec.LookPath("sleep")
+	require.NoError(t, err)
+
+	cfg := Config{KillTimeout: 500 * time.Millisecond}
+	s := newSupervisor(t.Context(), "test", "", os.Environ(), cfg, sleep, "60")
+	require.NoError(t, s.Start())
+
+	pid := s.PID()
+	exited, ok := s.currentExitedChan()
+	require.True(t, ok)
+
+	require.NoError(t, syscall.Kill(pid, syscall.SIGKILL))
+	<-exited
+
+	did, _ := s.handleUnsolicitedExit(exited)
+	assert.True(t, did, "matching observation must run the cleanup path")
+
+	assert.Zero(t, s.PID(), "state must be cleared after cleanup")
+	_, ok = s.currentExitedChan()
+	assert.False(t, ok, "no exited channel must remain after cleanup")
 }
 
 func TestSupervisor_KillsProcessGroup(t *testing.T) {


### PR DESCRIPTION
## Summary

When `burrow dev` saw the app child exit on its own (compile error, panic, port-in-use) and the user saved a file before the supervisor's exit-monitor goroutine finished its cleanup, the cleanup would cancel the brand-new child's context, killing it. The dev server recovered on the next save, but the symptom looked like "save → crash → nothing rebuilds." This was a TOCTOU race between `monitorAppExits` and `supervisor.Restart`.

## Root cause

`monitorAppExits` (`internal/dev/dev.go:135-165`) captured the current `exited` channel, then called `clearExited()` after the channel closed. `clearExited()` (`internal/dev/supervisor.go`) read `s.cancel` under the lock at call time — by which point a racing `Restart()` may have already installed a fresh generation's cancel. The old observer would then cancel the fresh child.

## Fix

Replace `clearExited()` with `handleUnsolicitedExit(observed)`. The new method checks `s.exited == observed` under the lock and returns early (with `did=false`) when the generation no longer matches; only the matching generation triggers state cleanup. `monitorAppExits` then `continue`s the outer loop on `did=false`, skipping the log line and never touching the fresh child's lifecycle.

## Tests

Two new unit tests in `internal/dev/supervisor_test.go`, both deterministic via `syscall.SIGKILL` on the child + manual `Restart()` between exit observation and the handler call:

- `TestSupervisor_HandleUnsolicitedExit_IgnoresStaleObservation` — late observer holding the OLD exited channel must NOT cancel the fresh child after a Restart.
- `TestSupervisor_HandleUnsolicitedExit_ActsOnCurrentObservation` — when the observation still matches the current generation, the cleanup path runs and state is cleared.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` — 1700/1700 pass
- [x] `mise run lint` — 0 issues
- [x] Manual: no behavioural change in the happy-path dev loop; the new gating only affects the "exit then quick restart" window