### PR TITLE
feat(auth): add WithDefaultRole option for invite-accept role assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ### Added
 
+- **`auth.WithDefaultRole(role)` constructor option.** Sets the role assigned to newly-registered users after `CreateUser` succeeds, so apps where every accepted invitee should be staff don't have to wrap the registration flow or run a post-hoc CLI. The first-user → `RoleAdmin` promotion still wins (a fresh deployment never locks itself out of `/admin/`), and an invalid role string makes `Configure` return an error at boot. Leaving the option unset preserves the historic `RoleUser` default.
 - **`mise run clean` and `mise run clean-all` tasks** in burrow itself and the project scaffold. `clean` removes build artifacts and generated files (coverage outputs, `bin/`, `tmp/`, `site/`, docs build output, `.tailwind/` source dirs, generated example static bundles); `clean-all` additionally wipes every gitignored `data/` runtime dir and every `*.db*` SQLite file anywhere in the tree. `clean-all` depends on `clean` so there's no copy-paste drift.
 - **`docs/getting-started/scaffold.md`** documents the output of `burrow new` — annotated file tree, full mise-task reference, dev/release loops, and what the scaffold deliberately omits. The Quick Start tip box, the index Minimal Example, and the Tooling CLI section now cross-link to it; `tooling.md` keeps the CLI-flag reference, the new page covers the generated project.
 

--- a/contrib/auth/app.go
+++ b/contrib/auth/app.go
@@ -80,6 +80,7 @@ type App[P any] struct {
 	renderer       Renderer
 	emailService   EmailService
 	authLayout     string
+	defaultRole    string
 	cancelCleanup  context.CancelFunc
 	cancelWebAuthn context.CancelFunc
 	config         *Config
@@ -126,6 +127,34 @@ func WithEmailService[P any](e EmailService) Option[P] {
 	return func(a *App[P]) { a.emailService = e }
 }
 
+// WithDefaultRole sets the role assigned to newly-registered users
+// after CreateUser succeeds. Useful for apps where every accepted
+// invitee is intended to be staff (e.g. invite-only blog engines with
+// no reader role) so they don't have to wrap the registration flow or
+// run a post-hoc CLI to promote users.
+//
+// The first-user → RoleAdmin promotion still wins: if the registrant
+// is the first user in the database, they become admin regardless of
+// this option. Valid values are [RoleUser], [RoleStaff], and
+// [RoleAdmin]; any other value makes Configure return an error.
+// Leaving the option unset preserves the historic default ([RoleUser]).
+func WithDefaultRole[P any](role string) Option[P] {
+	return func(a *App[P]) { a.defaultRole = role }
+}
+
+// validateDefaultRole reports whether the role string is acceptable as
+// a WithDefaultRole argument. The empty string is allowed and means
+// "no override — keep the default RoleUser behaviour."
+func validateDefaultRole(role string) error {
+	switch role {
+	case "", RoleUser, RoleStaff, RoleAdmin:
+		return nil
+	default:
+		return fmt.Errorf("auth: WithDefaultRole(%q): role must be one of %q, %q, %q (or empty for the default)",
+			role, RoleUser, RoleStaff, RoleAdmin)
+	}
+}
+
 // New creates a new auth app with the given options.
 // By default, the built-in HTML renderer and auth layout are used.
 // Use WithRenderer() and WithAuthLayout() to override.
@@ -146,6 +175,9 @@ func (a *App[P]) Dependencies() []string { return []string{"session", "csrf", "s
 
 func (a *App[P]) Configure(cfg *burrow.AppConfig, cmd *cli.Command) error {
 	if err := validateProfileType[P](); err != nil {
+		return err
+	}
+	if err := validateDefaultRole(a.defaultRole); err != nil {
 		return err
 	}
 

--- a/contrib/auth/app_test.go
+++ b/contrib/auth/app_test.go
@@ -213,6 +213,32 @@ func TestCountAdminUsers(t *testing.T) {
 	assert.Equal(t, 2, count)
 }
 
+func TestValidateDefaultRole(t *testing.T) {
+	cases := []struct {
+		name    string
+		role    string
+		wantErr bool
+	}{
+		{"empty string accepted (preserves default behaviour)", "", false},
+		{"RoleUser accepted", RoleUser, false},
+		{"RoleStaff accepted", RoleStaff, false},
+		{"RoleAdmin accepted", RoleAdmin, false},
+		{"unknown role rejected", "moderator", true},
+		{"case-sensitive — uppercase rejected", "STAFF", true},
+		{"whitespace rejected", " user", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDefaultRole(tc.role)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestSetUserRole(t *testing.T) {
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)

--- a/contrib/auth/handlers_registration.go
+++ b/contrib/auth/handlers_registration.go
@@ -127,6 +127,16 @@ func (a *App[P]) RegisterBegin(w http.ResponseWriter, r *http.Request) error {
 		slog.Info("first user registered as admin", "user_id", user.ID)
 	}
 
+	// Apply WithDefaultRole if configured and the admin promotion did
+	// not already lift the user above RoleUser.
+	if a.defaultRole != "" && user.Role == RoleUser {
+		if roleErr := a.repo.SetUserRole(ctx, user.ID, a.defaultRole); roleErr != nil {
+			slog.Error("failed to apply default role", "user_id", user.ID, "role", a.defaultRole, "error", roleErr)
+		} else {
+			user.Role = a.defaultRole
+		}
+	}
+
 	// Mark invite as used.
 	if validInvite != nil {
 		if markErr := a.repo.MarkInviteUsed(ctx, validInvite.ID, user.ID); markErr != nil {

--- a/contrib/auth/handlers_test.go
+++ b/contrib/auth/handlers_test.go
@@ -326,6 +326,85 @@ func TestRegisterBeginUsernameMode(t *testing.T) {
 	assert.Equal(t, "newuser", users[0].Username)
 }
 
+func TestRegisterBeginAppliesDefaultRole(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	ctx := context.Background()
+
+	// Seed an existing admin so the first-user promotion doesn't kick
+	// in and shadow the default-role assignment we're verifying.
+	admin, err := repo.CreateUser(ctx, "existing-admin")
+	require.NoError(t, err)
+	require.NoError(t, repo.SetUserRole(ctx, admin.ID, RoleAdmin))
+
+	h.defaultRole = RoleStaff
+
+	body := strings.NewReader(`{"username":"newcomer"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithSession(req, nil)
+	rec := httptest.NewRecorder()
+
+	err = h.RegisterBegin(rec, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := repo.GetUserByUsername(ctx, "newcomer")
+	require.NoError(t, err)
+	assert.Equal(t, RoleStaff, got.Role,
+		"WithDefaultRole(RoleStaff) should bump new users from RoleUser to RoleStaff")
+}
+
+func TestRegisterBeginAdminPromotionWinsOverDefaultRole(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	ctx := context.Background()
+
+	// No prior users → the registrant is the first → admin promotion
+	// fires before our default-role check sees user.Role == RoleUser.
+	h.defaultRole = RoleStaff
+
+	body := strings.NewReader(`{"username":"firstever"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithSession(req, nil)
+	rec := httptest.NewRecorder()
+
+	err := h.RegisterBegin(rec, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := repo.GetUserByUsername(ctx, "firstever")
+	require.NoError(t, err)
+	assert.Equal(t, RoleAdmin, got.Role,
+		"first user must become admin even when WithDefaultRole is set")
+}
+
+func TestRegisterBeginDefaultRoleUnsetPreservesRoleUser(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	ctx := context.Background()
+
+	// Seed an existing admin so the first-user promotion is out of the
+	// picture; the only thing being tested is "no option → no change".
+	admin, err := repo.CreateUser(ctx, "existing-admin")
+	require.NoError(t, err)
+	require.NoError(t, repo.SetUserRole(ctx, admin.ID, RoleAdmin))
+
+	// Sanity: option is unset on the test app.
+	require.Empty(t, h.defaultRole)
+
+	body := strings.NewReader(`{"username":"plainuser"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithSession(req, nil)
+	rec := httptest.NewRecorder()
+
+	err = h.RegisterBegin(rec, req)
+	require.NoError(t, err)
+
+	got, err := repo.GetUserByUsername(ctx, "plainuser")
+	require.NoError(t, err)
+	assert.Equal(t, RoleUser, got.Role)
+}
+
 func TestRegisterBeginMissingUsername(t *testing.T) {
 	h, _, _ := setupTestApp(t)
 	body := strings.NewReader(`{"username":""}`)

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -33,6 +33,12 @@ auth.New[auth.EmptyProfile](
 )
 ```
 
+Other constructor options:
+
+- `auth.WithEmailService(svc)` — wire up an email backend (see [Email Service](#email-service)).
+- `auth.WithLogoComponent(html)` — render a small logo above login/register/recovery pages.
+- `auth.WithDefaultRole(role)` — assign every newly-registered user a role other than `RoleUser` (see [Default Role for New Users](#default-role-for-new-users)).
+
 ## Default Templates
 
 The auth app ships HTML templates via `HasTemplates`. These templates use the global template set and are rendered with `burrow.Render()`. The auth app also implements `HasRequestFuncMap` to provide `currentUser`, `isAuthenticated`, and other request-scoped functions available in all templates.
@@ -335,6 +341,20 @@ func (r *myRenderer) LoginPage(w http.ResponseWriter, req *http.Request, loginRe
 ## Admin Integration
 
 The auth app implements `HasAdmin` to provide user and invite management in the admin panel with hand-written handlers. Admin views include user list with search and role filter, user edit form with last-admin demotion protection, and an htmx-powered inline invite creation form.
+
+## Default Role for New Users
+
+By default, newly-registered users land in `RoleUser`. For apps where every accepted invitee is expected to be staff — for example invite-only blog engines or internal tools with no reader role — `auth.WithDefaultRole` skips the "register, then promote" round-trip:
+
+```go
+auth.New[auth.EmptyProfile](
+    auth.WithDefaultRole(auth.RoleStaff),
+)
+```
+
+The first-user-becomes-admin promotion still wins: the very first user in an empty database becomes `RoleAdmin` regardless of this option, so a fresh deployment never locks itself out of `/admin/`. After that, every successful registration is assigned the configured role.
+
+Valid arguments are `auth.RoleUser`, `auth.RoleStaff`, `auth.RoleAdmin`, or the empty string (which behaves identically to not passing the option). Any other value makes `Configure` return an error at boot.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Closes the gap from `go-webapp-template-f202`. Today `contrib/auth`'s invite-accept flow always creates new users with `RoleUser`. Apps where every accepted invitee is intended to be staff (the concrete downstream is warren — invite-only blog engine with no reader role) had to either run a `set-role` CLI after every invite-accept or wrap the registration flow. Both are awkward.

The new constructor option does the assignment inline:

```go
auth.New[auth.EmptyProfile](
    auth.WithDefaultRole(auth.RoleStaff),
)
```

## Behaviour

- Applied in `handlers_registration.go` right after the first-user → `RoleAdmin` promotion, guarded by `a.defaultRole != "" && user.Role == RoleUser`. The admin promotion still wins so a fresh deployment never locks itself out of `/admin/`.
- A failing `SetUserRole` here is logged and ignored — same recovery shape as the existing admin-promotion block (the registration is not rolled back; the new user simply stays on `RoleUser` and an operator can fix it later).
- `Configure` calls `validateDefaultRole` and returns an error for anything other than `""`, `RoleUser`, `RoleStaff`, `RoleAdmin`. This catches typos at boot (`WithDefaultRole("staf")`) rather than at first registration.
- Unset option preserves the historic `RoleUser` default — no behaviour change for existing apps.

## Tests

- `TestValidateDefaultRole` — 7 table-driven sub-tests on the validation helper (empty, three valid roles, unknown string, uppercase, leading whitespace).
- `TestRegisterBeginAppliesDefaultRole` — seeds an admin so the first-user promotion is out of the picture, then verifies `WithDefaultRole(RoleStaff)` yields `RoleStaff`.
- `TestRegisterBeginAdminPromotionWinsOverDefaultRole` — fresh DB, `WithDefaultRole(RoleStaff)`, registrant becomes `RoleAdmin`.
- `TestRegisterBeginDefaultRoleUnsetPreservesRoleUser` — explicit backward-compatibility pin.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` — 1711/1711 (was 1700 before this change)
- [x] `mise run lint` — 0 issues
- [x] `mise run docs-build` — no warnings
- [x] `docs/contrib/auth.md` updated (Setup constructor-options list + new "Default Role for New Users" section)
- [x] CHANGELOG entry under Unreleased → Added