### PR TITLE
fix(scaffold): disable mise-action cache on check job to close zizmor finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Security
+
+- **Scaffold CI: `cache: false` on the check job's `mise-action` step** to close zizmor's `cache-poisoning` finding. The release job (which depends on `check` via `needs:`) builds release artifacts from the same toolchain — leaving the check-job cache enabled would let an untrusted PR branch poison build inputs that flow into a later release. Matches burrow's own `.github/workflows/ci.yml`, which already had `cache: false` on every mise-action call.
+
 ## 0.25.3 — 2026-05-25
 
 ### Added

--- a/cmd/burrow/templates/project/.github/workflows/ci.yml
+++ b/cmd/burrow/templates/project/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          cache: true
+          # Cache disabled to avoid zizmor's cache-poisoning concern: this
+          # job feeds into the release job via `needs:` and untrusted PR
+          # branches could otherwise populate the cache with malicious
+          # build artifacts. Matches burrow's own .github/workflows/ci.yml.
+          cache: false
 
       - run: mise run css
 


### PR DESCRIPTION
## Summary

Closes [code-scanning alert #8](https://github.com/oliverandrich/burrow/security/code-scanning/8) — `zizmor/cache-poisoning` (severity: error) on `cmd/burrow/templates/project/.github/workflows/ci.yml:25`.

The check job feeds into the release job via \`needs: [check, zizmor]\`. With \`cache: true\` on the check-job's \`mise-action\` step, an untrusted PR branch could populate the cache with malicious build artifacts that a later tag-triggered release job would then restore from — tainting the published binaries.

Burrow's own \`.github/workflows/ci.yml\` already has \`cache: false\` on every \`mise-action\` call (lines 31, 51, 71) for exactly this reason. The scaffold template was inconsistent — fixed here so every newly-generated project inherits the same safe default.

## Trade-off

Caching off makes the check job slower on each run (mise pulls all pinned tools fresh). For a single-developer scaffold this is acceptable; the trust model in a real CI matters more than 30-60s of toolchain cold-start.

## Test plan

- [x] \`mise run scaffold-smoke\` — scaffold generates + builds + tests pass
- [x] Diff matches burrow's own \`ci.yml\` cache-handling pattern (\`cache: false\`)
- [x] CHANGELOG entry under Unreleased → Security