### PR TITLE
feat(dev): watch .toml, .yml, .yaml in addition to .go/.html/.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- **`burrow dev` default watch extensions now include `.toml`, `.yml`, and `.yaml`** alongside the existing `.go` / `.html` / `.css`. Edits to translation bundles (`*.toml`) and config files now trigger a rebuild without an explicit `--watch-exts` override — fixes the silent failure mode where a translation-file fix didn't recover from a boot-time i18n check failure until the dev server was restarted by hand.
+
 ## 0.25.4 — 2026-05-25
 
 ### Security

--- a/docs/getting-started/scaffold.md
+++ b/docs/getting-started/scaffold.md
@@ -68,7 +68,7 @@ The shell app under `internal/app/` holds the layout, the homepage, the compiled
 
 1. `mise run setup` once after `burrow new` (or after cloning a teammate's project).
 2. `mise run dev`. The first run also writes `.env` if it doesn't exist, with mode `0600`. The file is gitignored — `burrow dev` reads it as a dotenv and injects every key into the app's environment before launching.
-3. Edit anything under `internal/app/templates/` or any `*.go` file. `burrow dev` debounces, rebuilds Tailwind CSS when templates change, then restarts the Go binary. Server defaults to <http://localhost:8080>.
+3. Edit anything under `internal/app/templates/`, any `*.go` file, or any `*.toml` / `*.yml` / `*.yaml` (translation bundles, app config). `burrow dev` debounces, rebuilds Tailwind CSS when templates change, then restarts the Go binary. Server defaults to <http://localhost:8080>.
 
 The pinned `SESSION_HASH_KEY` and `CSRF_KEY` in `.env` survive restarts so logged-in sessions and CSRF tokens don't break every save.
 

--- a/docs/guide/tailwind.md
+++ b/docs/guide/tailwind.md
@@ -201,7 +201,7 @@ run = "go tool burrow dev"
 mise run dev
 ```
 
-On any `.go`, `.html`, or `.css` edit inside the project:
+On any `.go`, `.html`, `.css`, `.toml`, `.yml`, or `.yaml` edit inside the project:
 
 1. `burrow dev` SIGTERMs the running app.
 2. It re-runs `burrow tailwind` once (no `--watch`), regenerating `internal/app/static/app.min.css`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,7 +235,7 @@ burrow dev [flags]
 
 - **App path:** exactly one `./cmd/<name>/main.go` → that's the entry-point. Zero or multiple → error; pass `--app`.
 - **Tailwind:** `tailwind.css` at the project root *and* exactly one `internal/<app>/static/` directory → both are inferred. Any other shape → Tailwind co-watcher stays off (pass `--css-in` / `--css-out` explicitly to override).
-- **Watched extensions:** `.go`, `.html`, `.css`. `*_test.go` is excluded.
+- **Watched extensions:** `.go`, `.html`, `.css`, `.toml`, `.yml`, `.yaml`. `*_test.go` is excluded. TOML and YAML are included so edits to translation bundles (e.g. go-i18n `*.toml`) and config files trigger a rebuild — without this, a fix for a boot-time check that failed on stale content wouldn't recover until the dev server was restarted by hand.
 - **Excluded directories:** `.git`, `.beans`, `node_modules`, `tmp`, `testdata`, `.tailwind`, plus the auto-detected CSS output directory (to avoid a Tailwind ↔ watcher feedback loop).
 
 ### Env file format

--- a/internal/dev/config.go
+++ b/internal/dev/config.go
@@ -35,7 +35,10 @@ type Config struct {
 	CSSOut string
 
 	// WatchExts is the set of file extensions (lowercase, leading dot)
-	// that trigger a restart, e.g. {".go", ".html", ".css"}.
+	// that trigger a restart, e.g. {".go", ".html", ".css", ".toml",
+	// ".yml", ".yaml"}. TOML and YAML are included so changes to
+	// translation bundles and config files are picked up without an
+	// explicit `--watch-exts` override.
 	WatchExts []string
 
 	// ExcludeDirs is the set of directory names (no path separators)
@@ -73,7 +76,7 @@ const (
 )
 
 var (
-	defaultWatchExts   = []string{".go", ".html", ".css"}
+	defaultWatchExts   = []string{".go", ".html", ".css", ".toml", ".yml", ".yaml"}
 	defaultExcludeDirs = []string{".git", ".beans", "node_modules", "tmp", "testdata", ".tailwind"}
 )
 

--- a/internal/dev/config_test.go
+++ b/internal/dev/config_test.go
@@ -21,7 +21,7 @@ func TestDiscover_ConventionalScaffoldLayout(t *testing.T) {
 	assert.Equal(t, "./cmd/myapp", cfg.AppPath)
 	assert.Equal(t, "tailwind.css", cfg.CSSIn)
 	assert.Equal(t, filepath.Join("internal", "app", "static", "app.min.css"), cfg.CSSOut)
-	assert.Equal(t, []string{".go", ".html", ".css"}, cfg.WatchExts)
+	assert.Equal(t, []string{".go", ".html", ".css", ".toml", ".yml", ".yaml"}, cfg.WatchExts)
 	assert.Equal(t, ".env", cfg.EnvFile)
 	assert.Equal(t, 300*time.Millisecond, cfg.Debounce)
 	assert.Equal(t, 500*time.Millisecond, cfg.KillTimeout)


### PR DESCRIPTION
## Summary

A real-world dev session showed this failure mode: a translation TOML had reserved-vs-flat key collisions that crashed the app at boot (`load translations from "app": reserved keys [Other] mixed with unreserved keys [Content Settings]` → `exit status 1`). The user fixed the TOML and saved it, but \`burrow dev\` didn't rebuild — the default watch list (\`.go\`, \`.html\`, \`.css\`) doesn't include \`.toml\`. Symptom: "save my fix, nothing happens, restart needed."

This PR adds \`.toml\`, \`.yml\`, and \`.yaml\` to \`defaultWatchExts\`, so translation bundles and config files trigger a rebuild without an explicit \`--watch-exts\` override.

## Why these three

- \`.toml\` — go-i18n translation bundles, project config (\`.mise.toml\`, \`pyproject.toml\`-shaped configs)
- \`.yml\` / \`.yaml\` — workflow files (rare in-process edits), config files (\`.golangci.yml\`, \`zensical.yml\`), translations in YAML form

Neither expands the watch set into noisy territory (e.g. \`.md\` would trigger constant rebuilds during doc edits; \`.json\` is too broad — fixture data, package-lock-equivalents).

## Trade-off

Slightly more file-system events during normal editing. The debounce window collapses bursts so the cost is one extra debounce evaluation per save, not one extra rebuild. Already mitigated by \`ExcludeDirs\` (\`.git\`, \`node_modules\`, \`tmp\`, \`testdata\`, \`.tailwind\`).

## Test plan

- [x] TDD: \`TestDiscover_ConventionalScaffoldLayout\` updated to expect the new list (red → green)
- [x] \`go test -race ./internal/dev/\` — 42/42 pass
- [x] \`go test -race ./...\` — full module pass
- [x] \`mise run lint\` — 0 issues
- [x] \`mise run docs-build\` — no warnings
- [x] Two doc stale spots fixed: \`docs/guide/tailwind.md\` ("On any \`.go\`, \`.html\`, or \`.css\` edit") and \`docs/getting-started/scaffold.md\` (dev-loop step 3)
- [x] CHANGELOG entry under Unreleased → Changed