### PR TITLE
feat(csrf): add ExemptPaths capability interface for webhook receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- **`csrf.ExemptPaths` capability interface** for apps that own webhook routes (Webmention inbound, ActivityPub inbox, payment callbacks). An app returns its exempt paths from `CSRFExemptPaths() []string` and the csrf app discovers every implementor at boot, merges the declarations into a single matcher, and bypasses `gorilla/csrf.UnsafeSkipCheck` for matching requests. Keeps the declaration local to the app that owns the route — `main.go` stays unaware. Patterns are minimal by design: exact (`"/webmention"`) and prefix (`"/inbox/"`).
+
 ## 0.25.5 — 2026-05-25
 
 ### Changed

--- a/contrib/csrf/app.go
+++ b/contrib/csrf/app.go
@@ -5,20 +5,44 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	gorillacsrf "github.com/gorilla/csrf"
 	"github.com/oliverandrich/burrow"
 	"github.com/oliverandrich/burrow/internal/cryptokey"
+	"github.com/oliverandrich/burrow/registry"
 	"github.com/urfave/cli/v3"
 )
+
+// ExemptPaths is implemented by apps that want specific URL paths to
+// bypass CSRF token validation — typically webhook receivers (webmention
+// inbound, ActivityPub inbox, payment callbacks) that accept POSTs from
+// external services without a CSRF token by design.
+//
+// The csrf app discovers every implementor in the registry during boot
+// and merges their declarations into a single matcher. This keeps the
+// declaration local to the app that owns the route: a Webmention contrib
+// returns "/webmention" from its own CSRFExemptPaths, the application's
+// main.go stays unaware of which routes need bypassing.
+//
+// Pattern syntax (minimal by design):
+//
+//   - "/webmention" — exact match (matches /webmention, NOT /webmention/x).
+//   - "/inbox/"     — prefix match (trailing slash; matches /inbox/alice,
+//     /inbox/bob/feed, NOT /inbox).
+type ExemptPaths interface {
+	CSRFExemptPaths() []string
+}
 
 // New creates a new CSRF app.
 func New() *App { return &App{} }
 
 // App implements CSRF protection as a burrow contrib app.
 type App struct {
-	protect func(http.Handler) http.Handler
-	secure  bool
+	protect  func(http.Handler) http.Handler
+	secure   bool
+	registry *registry.Registry
+	exempt   *exemptMatcher
 }
 
 func (a *App) Name() string { return "csrf" }
@@ -36,6 +60,7 @@ func (a *App) Flags(configSource func(key string) cli.ValueSource) []cli.Flag {
 func (a *App) Configure(cfg *burrow.AppConfig, cmd *cli.Command) error {
 	keyHex := cmd.String("csrf-key")
 	secure := cfg.Config != nil && cfg.Config.IsHTTPS()
+	a.registry = cfg.Registry
 	return a.configure(keyHex, secure)
 }
 
@@ -48,6 +73,7 @@ func (a *App) configure(keyHex string, secure bool) error {
 	}
 
 	a.secure = secure
+	a.exempt = buildExemptMatcher(a.registry)
 	a.protect = gorillacsrf.Protect(
 		key,
 		gorillacsrf.Secure(secure),
@@ -89,13 +115,76 @@ func (a *App) csrfMiddleware(next http.Handler) http.Handler {
 
 	wrapped := a.protect(bridged)
 
-	// gorilla/csrf assumes HTTPS by default. For plaintext HTTP deployments,
-	// mark each request so gorilla skips HTTPS-only referer checks.
-	if !a.secure {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			wrapped.ServeHTTP(w, gorillacsrf.PlaintextHTTPRequest(r))
-		})
-	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Webhook receivers and similar cross-origin endpoints can opt
+		// their path out of CSRF validation via the ExemptPaths capability
+		// interface. UnsafeSkipCheck must be applied to the request
+		// BEFORE gorilla.Protect runs.
+		if a.exempt.matches(r.URL.Path) {
+			r = gorillacsrf.UnsafeSkipCheck(r)
+		}
+		// gorilla/csrf assumes HTTPS by default. For plaintext HTTP
+		// deployments, mark each request so gorilla skips HTTPS-only
+		// referer checks.
+		if !a.secure {
+			r = gorillacsrf.PlaintextHTTPRequest(r)
+		}
+		wrapped.ServeHTTP(w, r)
+	})
+}
 
-	return wrapped
+// exemptMatcher is the merged exempt-path lookup table built once at
+// boot from every registry app that implements ExemptPaths. The matcher
+// is safe to call when nil — it returns false for every path.
+type exemptMatcher struct {
+	exact  map[string]struct{}
+	prefix []string // each entry already validated to end with "/"
+}
+
+// buildExemptMatcher walks the registry collecting every ExemptPaths
+// declaration. Returns nil when the registry is nil (e.g. tests that
+// construct the app via configure() without a Configure call) or when
+// no app implements the interface — both are normal modes.
+func buildExemptMatcher(reg *registry.Registry) *exemptMatcher {
+	if reg == nil {
+		return nil
+	}
+	m := &exemptMatcher{exact: map[string]struct{}{}}
+	for _, app := range registry.Apps(reg) {
+		provider, ok := app.(ExemptPaths)
+		if !ok {
+			continue
+		}
+		for _, p := range provider.CSRFExemptPaths() {
+			if p == "" {
+				continue
+			}
+			if strings.HasSuffix(p, "/") {
+				m.prefix = append(m.prefix, p)
+			} else {
+				m.exact[p] = struct{}{}
+			}
+		}
+	}
+	if len(m.exact) == 0 && len(m.prefix) == 0 {
+		return nil
+	}
+	return m
+}
+
+// matches reports whether path is exempt from CSRF validation. The
+// receiver may be nil — that case is treated as "no exemptions".
+func (m *exemptMatcher) matches(path string) bool {
+	if m == nil {
+		return false
+	}
+	if _, ok := m.exact[path]; ok {
+		return true
+	}
+	for _, p := range m.prefix {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/contrib/csrf/app_test.go
+++ b/contrib/csrf/app_test.go
@@ -10,10 +10,41 @@ import (
 
 	gorillacsrf "github.com/gorilla/csrf"
 	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
+
+// exemptStubApp is a test fixture: a minimal App that also implements
+// ExemptPaths, so we can put it into a registry and verify the csrf
+// middleware picks the paths up.
+type exemptStubApp struct {
+	name  string
+	paths []string
+}
+
+func (s *exemptStubApp) Name() string              { return s.name }
+func (s *exemptStubApp) CSRFExemptPaths() []string { return s.paths }
+
+// newTestAppWithExempts builds a csrf app whose registry contains stub
+// apps with the given exempt-path declarations. Each call to the
+// function adds one stub app named "stub-<i>" with its paths.
+func newTestAppWithExempts(t *testing.T, paths ...[]string) *App {
+	t.Helper()
+	reg := registry.New()
+	for i, p := range paths {
+		registry.Add(reg, &exemptStubApp{name: stubName(i), paths: p})
+	}
+	a := New()
+	a.registry = reg
+	require.NoError(t, a.configure("", false))
+	return a
+}
+
+func stubName(i int) string {
+	return "stub-" + string(rune('a'+i))
+}
 
 // Compile-time interface assertions.
 var (
@@ -355,4 +386,116 @@ func TestSecureDerivedFromBaseURL(t *testing.T) {
 			assert.NotNil(t, a.protect)
 		})
 	}
+}
+
+// --- ExemptPaths ---
+
+// postWithoutToken issues a POST to the given path and returns the recorder.
+// Helper for the exempt-path tests; the only thing they care about is whether
+// the response is 200 (exempted) or 403 (still enforced).
+func postWithoutToken(t *testing.T, handler http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader("data=value"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestExemptPaths_ExactMatchBypassesValidation(t *testing.T) {
+	a := newTestAppWithExempts(t, []string{"/webmention"})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	rr := postWithoutToken(t, handler, "/webmention")
+
+	assert.Equal(t, http.StatusOK, rr.Code, "exact-path exempt must bypass CSRF check")
+}
+
+func TestExemptPaths_PrefixMatchBypassesValidation(t *testing.T) {
+	a := newTestAppWithExempts(t, []string{"/inbox/"})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	for _, path := range []string{"/inbox/alice", "/inbox/bob/feed"} {
+		t.Run(path, func(t *testing.T) {
+			rr := postWithoutToken(t, handler, path)
+			assert.Equal(t, http.StatusOK, rr.Code, "prefix exempt %q must match %q", "/inbox/", path)
+		})
+	}
+}
+
+func TestExemptPaths_DoesNotMatchUnrelatedPath(t *testing.T) {
+	a := newTestAppWithExempts(t, []string{"/webmention"})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	rr := postWithoutToken(t, handler, "/other")
+
+	assert.Equal(t, http.StatusForbidden, rr.Code, "non-exempt paths must still require a CSRF token")
+}
+
+func TestExemptPaths_ExactDoesNotMatchSubpath(t *testing.T) {
+	a := newTestAppWithExempts(t, []string{"/webmention"})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	rr := postWithoutToken(t, handler, "/webmention/extra")
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"exact entry (no trailing slash) must not match descendant paths")
+}
+
+func TestExemptPaths_MergedAcrossMultipleApps(t *testing.T) {
+	a := newTestAppWithExempts(t,
+		[]string{"/webmention"},
+		[]string{"/inbox/"},
+	)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	for _, path := range []string{"/webmention", "/inbox/alice"} {
+		t.Run(path, func(t *testing.T) {
+			rr := postWithoutToken(t, handler, path)
+			assert.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
+}
+
+func TestExemptPaths_NoProviderAppsLeavesBehaviourUnchanged(t *testing.T) {
+	// Registry exists but no app implements ExemptPaths.
+	a := newTestAppWithExempts(t)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	rr := postWithoutToken(t, handler, "/anything")
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestExemptPaths_NilRegistryIsSafe(t *testing.T) {
+	// newTestApp (used elsewhere) does not set a registry — this guards
+	// against a nil-pointer panic in the matcher build path.
+	a := newTestApp(t)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	rr := postWithoutToken(t, handler, "/anything")
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"a csrf app without a registry must still enforce CSRF (no panic, no silent bypass)")
+}
+
+func TestExemptPaths_GetOnExemptPathStillSucceeds(t *testing.T) {
+	// Sanity check: exempting a path doesn't break ordinary GETs (which
+	// were already accepted by csrf because GET isn't state-changing).
+	a := newTestAppWithExempts(t, []string{"/webmention"})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := a.Middleware()[0](inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/webmention", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
 }

--- a/docs/contrib/csrf.md
+++ b/docs/contrib/csrf.md
@@ -102,6 +102,37 @@ token := csrf.Token(r.Context())
     openssl rand -hex 32
     ```
 
+## Exempting Webhook Paths
+
+Cross-origin webhook receivers — Webmention inbound, ActivityPub inbox, payment callbacks — accept POSTs from external services without a CSRF token by design. The csrf app honours a capability interface so the app that owns the route declares the exemption locally:
+
+```go
+package webmention
+
+import (
+    "github.com/oliverandrich/burrow/contrib/csrf"
+)
+
+// Compile-time check.
+var _ csrf.ExemptPaths = (*App)(nil)
+
+func (a *App) CSRFExemptPaths() []string {
+    return []string{"/webmention"}
+}
+```
+
+At boot the csrf app walks the registry, collects every `CSRFExemptPaths()` return value, and builds a single matcher. No coordination from `main.go` — adding a new webhook receiver only requires implementing the interface on its app.
+
+**Pattern syntax (minimal by design):**
+
+- `"/webmention"` — exact match (matches `/webmention`, **not** `/webmention/x`).
+- `"/inbox/"` — prefix match (trailing slash; matches `/inbox/alice`, `/inbox/bob/feed`, **not** `/inbox`).
+
+No glob or chi-style placeholders. Apps with more complex routing constraints should list each path explicitly or front a prefix-matched subspace and gate further inside their handler.
+
+!!! warning "Use sparingly"
+    Each exempt path is a hole in CSRF protection. Limit them to endpoints that legitimately accept off-domain POSTs and validate authenticity by other means (HTTP signatures for Webmention, signed payloads for payment webhooks, etc.).
+
 ## Cookie Properties
 
 - `HttpOnly: true` — not accessible from JavaScript


### PR DESCRIPTION
## Summary

Closes `go-webapp-template-20xd`. Cross-origin webhook receivers — Webmention inbound, ActivityPub inbox, payment callbacks — POST without a CSRF token by design and currently get a `403 Forbidden` from `contrib/csrf`. The downstream blocker is `warren` (Webmention + ActivityPub inbox).

The design follows what we discussed: **locality wins over a `main.go`-level option list**. An app that owns a webhook route declares the exemption from within its own package:

```go
// In contrib/webmention or warren's inbox app
func (a *App) CSRFExemptPaths() []string {
    return []string{"/webmention"}
}
```

At boot the csrf app walks the registry, picks up every `CSRFExemptPaths()` return value, and merges them into a single matcher. `main.go` stays unaware; renaming a webhook route is a single-file change in the owning app.

## Why not `csrf.WithExemptPath(...)` on `csrf.New()`

- Several webhook receivers in one project → main.go becomes a list of route literals it shouldn't know about
- The route belongs to the app that handles it; the exemption should travel with the route
- Same pattern burrow already uses for `HasAdmin`, `HasJobs`, `HasTranslations` — declarative capability interfaces over imperative configuration

## Why not a downstream-mountable middleware

Tried in the design discussion: `r.Post("/webmention", csrf.Exempt(handler))`. The constraint that ruined it: `csrf.App.Middleware()` is applied at the root router, so chi runs it **outside** any per-route middleware. `gorilla/csrf.UnsafeSkipCheck` must be applied **before** `gorilla.Protect`. The only way to get a per-route middleware to run first would be to flip csrf from "global default" to "per-route opt-in" — a breaking change to every Burrow app.

The capability-interface design gets locality without that flip.

## Pattern syntax

Two cases only, no glob engine:

- `"/webmention"` — exact (matches `/webmention`, NOT `/webmention/x`)
- `"/inbox/"` — prefix (trailing slash; matches `/inbox/alice`, `/inbox/bob/feed`, NOT `/inbox`)

The matcher is built once at boot inside `Configure` and stored on the app. A nil registry (e.g. in tests using the internal `configure()` helper) is treated as "no exemptions"; a registry without any `ExemptPaths` implementor returns a nil matcher and the existing csrf path is unchanged.

## Tests

8 new tests in `contrib/csrf/app_test.go`, all using a small `exemptStubApp` fixture in the test file:

- exact match bypasses (POST `/webmention` without token → 200)
- prefix match bypasses (POST `/inbox/alice`, `/inbox/bob/feed` → 200)
- unrelated path still enforces (POST `/other` → 403)
- exact entry doesn't match subpaths (POST `/webmention/extra` → 403)
- merged across multiple apps (each declares its own exempts)
- registry with no `ExemptPaths` providers leaves behaviour unchanged
- nil registry is safe (no panic, no silent bypass)
- GET on an exempt path still succeeds (sanity)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./contrib/csrf/` — 38/38 pass
- [x] `go test -race ./...` — full module pass
- [x] `mise run lint` — 0 issues
- [x] `mise run docs-build` — no warnings
- [x] `docs/contrib/csrf.md` updated with a dedicated section + a "use sparingly" warning
- [x] CHANGELOG under Unreleased → Added