### PR TITLE
feat(admin,auth): commit form templates to hx-post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- **contrib/admin + contrib/auth: form templates commit to `hx-post`.** Admin user-edit, recovery-codes ack, and admin logout drop their `method=post` no-JS fallbacks — `contrib/auth` is WebAuthn-only and admin sits behind `RequireAuth + RequireStaff`, so those paths were unreachable. The example `notes` app follows the same pattern. No runtime behaviour change. See [admin → JavaScript required](https://burrow.andrich.dev/contrib/admin/#javascript-required).
+
 ## 0.25.6 — 2026-05-25
 
 ### Added

--- a/contrib/admin/templates/layout.html
+++ b/contrib/admin/templates/layout.html
@@ -24,7 +24,7 @@
                     </svg>
                     {{ .Username }}
                 </span>
-                <form method="post" action="/auth/logout" hx-boost="false">
+                <form hx-post="/auth/logout">
                     <input type="hidden" name="gorilla.csrf.Token" value="{{ csrfToken }}">
                     <button type="submit"
                             class="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800">

--- a/contrib/admin/templates_test.go
+++ b/contrib/admin/templates_test.go
@@ -1,0 +1,49 @@
+package admin
+
+import (
+	"html/template"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdminLayoutParses pins that admin/layout.html is well-formed Go
+// html/template. Unit tests elsewhere stub the executor, so without this
+// check a missing `{{ end }}` (or an introduced syntax error during the
+// hx-post migration) would only surface at server boot.
+func TestAdminLayoutParses(t *testing.T) {
+	funcMap := template.FuncMap{
+		"t":             func(...any) string { return "" },
+		"lang":          func() string { return "en" },
+		"staticURL":     func(string) string { return "" },
+		"csrfToken":     func() string { return "" },
+		"csrfHxHeaders": func() template.HTMLAttr { return "" },
+		"currentUser":   func() any { return nil },
+		"messages":      func() []any { return nil },
+	}
+	body, err := os.ReadFile("templates/layout.html")
+	require.NoError(t, err)
+	tmpl, err := template.New("admin/layout").Funcs(funcMap).Parse(string(body))
+	require.NoError(t, err, "admin/layout must parse cleanly")
+	assert.NotNil(t, tmpl.Lookup("admin/layout"))
+}
+
+// TestAdminLayoutLogoutFormIsHxPost pins the JS-required convention: the
+// admin layout's logout form submits via hx-post under the body's hx-boost
+// container, and does not opt out of boosting. The previous form fallback
+// was dead code because every admin page is gated behind WebAuthn login.
+// See docs/contrib/admin.md ("JavaScript required") for the full rationale.
+func TestAdminLayoutLogoutFormIsHxPost(t *testing.T) {
+	body, err := os.ReadFile("templates/layout.html")
+	require.NoError(t, err)
+	src := string(body)
+
+	assert.Contains(t, src, `<form hx-post="/auth/logout">`,
+		"admin layout logout form must submit via hx-post on the form element (admin mandates JS)")
+	assert.NotContains(t, src, `<form method="post" action="/auth/logout"`,
+		"admin layout logout form must not fall back to method=post (dead code)")
+	assert.NotContains(t, src, `hx-boost="false"`,
+		"admin layout must not opt out of hx-boost — the body container drives nav and form submission consistently")
+}

--- a/contrib/auth/default_renderer_test.go
+++ b/contrib/auth/default_renderer_test.go
@@ -165,7 +165,10 @@ func TestDefaultRendererRecoveryCodesPage(t *testing.T) {
 	assert.Contains(t, body, "aaaa-bbbb-cccc")
 	assert.Contains(t, body, "dddd-eeee-ffff")
 	assert.Contains(t, body, "<article ", "recovery codes page should be wrapped in a card")
-	assert.Contains(t, body, "/auth/recovery-codes/ack")
+	assert.Contains(t, body, `hx-post="/auth/recovery-codes/ack"`,
+		"recovery-codes ack form must submit via hx-post (admin/auth contribs mandate JS)")
+	assert.NotContains(t, body, `method="POST" action="/auth/recovery-codes/ack"`,
+		"recovery-codes ack form must not fall back to method=POST (dead code)")
 }
 
 func TestDefaultRendererVerifyPendingPage(t *testing.T) {

--- a/contrib/auth/templates/admin_user_form.html
+++ b/contrib/auth/templates/admin_user_form.html
@@ -11,7 +11,7 @@
 <header class="mb-4">
     <h2 class="text-2xl font-bold tracking-tight">{{ t "Edit" }} {{ .User.Username }}</h2>
 </header>
-<form method="post" action="/admin/users/{{ .User.ID }}" class="space-y-3">
+<form hx-post="/admin/users/{{ .User.ID }}" hx-target="#main" hx-swap="innerHTML" class="space-y-3">
     <input type="hidden" name="gorilla.csrf.Token" value="{{ csrfToken }}">
     {{- range .Fields }}
     {{- template "auth/admin_user_field" . }}

--- a/contrib/auth/templates/recovery.html
+++ b/contrib/auth/templates/recovery.html
@@ -2,7 +2,7 @@
 <p class="mb-3 text-sm">{{ t "recovery-codes-description" }}</p>
 <pre class="mb-4 overflow-x-auto rounded-md bg-gray-100 p-3 font-mono text-sm dark:bg-gray-800"><code>{{ range $i, $code := .Codes }}{{ if $i }}
 {{ end }}{{ $code }}{{ end }}</code></pre>
-<form method="POST" action="/auth/recovery-codes/ack">
+<form hx-post="/auth/recovery-codes/ack">
     <input type="hidden" name="gorilla.csrf.Token" value="{{ csrfToken }}"/>
     <button type="submit"
         class="w-full rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700">

--- a/contrib/auth/templates_test.go
+++ b/contrib/auth/templates_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdminUserFormIsHxPost pins the JS-required convention: admin forms
+// submit via hx-post, not a traditional method=post. The form fallback was
+// dead code because contrib/auth is WebAuthn-only and contrib/admin sits
+// behind RequireStaff — both demand JS already. See docs/contrib/admin.md
+// ("JavaScript required") for the full rationale.
+func TestAdminUserFormIsHxPost(t *testing.T) {
+	body, err := os.ReadFile("templates/admin_user_form.html")
+	require.NoError(t, err)
+	src := string(body)
+
+	assert.Contains(t, src, `<form hx-post="/admin/users/{{ .User.ID }}"`,
+		"admin_user_form must submit via hx-post on the form element (admin mandates JS)")
+	assert.NotContains(t, src, `<form method="post" action="/admin/users/`,
+		"admin_user_form must not fall back to method=post (dead code)")
+	assert.NotContains(t, src, `<form method="POST" action="/admin/users/`,
+		"admin_user_form must not fall back to method=POST (dead code)")
+}
+
+// TestRecoveryCodesAckFormIsHxPost pins the same convention for the
+// recovery-codes acknowledgement form: the user is logged in (just
+// regenerated codes) and JS is already required by WebAuthn.
+func TestRecoveryCodesAckFormIsHxPost(t *testing.T) {
+	body, err := os.ReadFile("templates/recovery.html")
+	require.NoError(t, err)
+	src := string(body)
+
+	assert.Contains(t, src, `<form hx-post="/auth/recovery-codes/ack">`,
+		"recovery-codes ack form must submit via hx-post on the form element")
+	assert.NotContains(t, src, `<form method="POST" action="/auth/recovery-codes/ack"`,
+		"recovery-codes ack form must not use method=POST")
+	assert.NotContains(t, src, `<form method="post" action="/auth/recovery-codes/ack"`,
+		"recovery-codes ack form must not use method=post")
+}

--- a/docs/contrib/admin.md
+++ b/docs/contrib/admin.md
@@ -6,6 +6,17 @@ Admin panel coordinator that discovers and mounts admin views from other apps.
 
 **Requires:** an app implementing `burrow.AdminAuth` (e.g., `contrib/auth`)
 
+## JavaScript required
+
+The admin contrib mandates JavaScript. The bundled `contrib/auth` is WebAuthn-only (passkeys cannot work without JS), and every admin page sits behind `RequireAuth + RequireStaff`, so the no-JS form fallback never runs in practice. The admin layout reflects this:
+
+- **Nav** uses `<a href>` inside an `hx-boost` container on `<body>`. Semantic HTML stays intact — screen readers, right-click-new-tab, bookmarks, and direct URL reloads all keep working — and htmx upgrades the click into a fragment swap.
+- **Form submits** use `hx-post` with `hx-target="#main" hx-swap="innerHTML"`. Validation errors re-render the form fragment into `#main`; success uses `htmx.SmartRedirect` (which sets `HX-Redirect` to drive a full navigation).
+- **Destructive actions** (delete, deactivate) use `<button hx-post>`, not link-shaped triggers — they shouldn't be reachable via bookmark or prefetch.
+- **CSRF** is carried via `csrfHxHeaders` on `<body>` (auto-injected `X-CSRF-Token` for every htmx request) plus a hidden `gorilla.csrf.Token` input in each form for belt-and-suspenders.
+
+Downstream `HasAdmin` apps should follow the same conventions. See `contrib/auth/templates/admin_user_form.html` and `contrib/auth/admin_handlers.go` (`adminUpdateUser`) for the validation-error / success pair.
+
 ## Setup
 
 ```go

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -9,6 +9,9 @@ WebAuthn (passkey) authentication with recovery codes, email verification, and i
 !!! note "Generic over a Profile type"
     `auth.User`, `auth.App`, `auth.Repository`, `auth.CurrentUser`, and `auth.MustCurrentUser` are all generic over a `Profile` type parameter that holds app-specific extension fields. Examples below use `auth.EmptyProfile` for apps that don't extend the user. To add display name, bio, avatar, social links, or other custom fields, see [Extending the User](auth-profile.md).
 
+!!! info "JavaScript required"
+    WebAuthn calls `navigator.credentials.create()` / `.get()`, so registration and sign-in cannot complete without JavaScript. Every page protected by `RequireAuth` therefore sits behind a JS-capable client; auth-rendered forms (recovery-code acknowledgement, admin user edit, logout) use `hx-post` and do not carry a `method=post` fallback. See [admin → JavaScript required](admin.md#javascript-required) for the full convention.
+
 ## Setup
 
 ```go

--- a/example/notes/internal/app/templates/app/layout.html
+++ b/example/notes/internal/app/templates/app/layout.html
@@ -51,16 +51,9 @@
             {{ if .IsAdmin -}}
             <li><a href="/admin" class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800">{{ template "app/icon_gear" . }} {{ t "layout-admin" }}</a></li>
             {{- end }}
-            <li><a href="#" id="logout-link" class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800">{{ template "app/icon_box_arrow_right" . }} {{ t "layout-sign-out" }}</a></li>
+            <li><button type="button" hx-post="/auth/logout" class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-gray-100 dark:hover:bg-gray-800">{{ template "app/icon_box_arrow_right" . }} {{ t "layout-sign-out" }}</button></li>
         </ul>
     </details>
-    <form method="post" action="/auth/logout" id="logout-form" hidden>{{ csrfField }}</form>
-    <script>
-        document.getElementById("logout-link").addEventListener("click",function(e){
-            e.preventDefault();
-            document.getElementById("logout-form").submit();
-        });
-    </script>
 </li>
 {{- else -}}
 <li>

--- a/example/notes/internal/notes/notes_test.go
+++ b/example/notes/internal/notes/notes_test.go
@@ -383,8 +383,9 @@ func TestNewNoteHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	body := rec.Body.String()
 	assert.Contains(t, body, "notes-new-title")
-	assert.Contains(t, body, `action="/notes"`)
 	assert.Contains(t, body, `hx-post="/notes"`)
+	assert.NotContains(t, body, `action="/notes"`,
+		"form must not carry a method=post fallback (JS is required)")
 	assert.Contains(t, body, `name="title"`)
 	assert.Contains(t, body, `name="content"`)
 	assert.JSONEq(t, `{"openDialog":"modal"}`, rec.Header().Get("HX-Trigger-After-Swap"))
@@ -521,7 +522,7 @@ func TestCreateNoteValidationErrorHTMX(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 	body := rec.Body.String()
 	assert.Contains(t, body, "notes-new-title")
-	assert.Contains(t, body, `action="/notes"`)
+	assert.Contains(t, body, `hx-post="/notes"`)
 	assert.Contains(t, body, `aria-invalid="true"`)
 
 	// No note should have been created.
@@ -561,7 +562,7 @@ func TestCreateNoteValidationErrorNonHTMX(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 	body := rec.Body.String()
 	assert.Contains(t, body, "notes-new-title")
-	assert.Contains(t, body, `action="/notes"`)
+	assert.Contains(t, body, `hx-post="/notes"`)
 }
 
 func TestCreateNoteUnauthenticatedPanics(t *testing.T) {
@@ -610,8 +611,9 @@ func TestEditNoteHTMX(t *testing.T) {
 	assert.Contains(t, body, "notes-edit-title")
 	assert.Contains(t, body, "Edit Me")
 	assert.Contains(t, body, "Original")
-	assert.Contains(t, body, `action="/notes/`+note.ID+`"`)
 	assert.Contains(t, body, `hx-post="/notes/`+note.ID+`"`)
+	assert.NotContains(t, body, `action="/notes/`+note.ID+`"`,
+		"form must not carry a method=post fallback (JS is required)")
 	assert.JSONEq(t, `{"openDialog":"modal"}`, rec.Header().Get("HX-Trigger-After-Swap"))
 }
 

--- a/example/notes/internal/notes/templates/notes/form.html
+++ b/example/notes/internal/notes/templates/notes/form.html
@@ -12,8 +12,7 @@
         {{- end }}
     </div>
     {{- end }}
-    <form method="post" action="{{ .Action }}"
-          hx-post="{{ .Action }}"
+    <form hx-post="{{ .Action }}"
           hx-target="#modal"
           hx-swap="innerHTML"
           class="space-y-3">


### PR DESCRIPTION
## Summary

- Admin user-edit, recovery-codes ack, and admin logout forms drop their `method=post` no-JS fallbacks. `contrib/auth` is WebAuthn-only and `contrib/admin` sits behind `RequireAuth + RequireStaff`, so those paths were unreachable in practice.
- Example `notes` app aligned with the same pattern: `notes/form.html` drops the belt-and-suspenders `method=post`; `app/layout.html` logout becomes `<button hx-post>` and ditches the hidden form + JS-submit shim.
- New pin tests in `contrib/{auth,admin}/templates_test.go` lock the convention; `admin/layout.html` also has a parse-time smoke test so a stray `{{ end }}` would fail unit tests instead of only at server boot.
- `docs/contrib/admin.md` gained a top-level `## JavaScript required` section documenting the convention (nav via `hx-boost`, forms via `hx-post`, destructive actions via `<button hx-post>`, CSRF via `csrfHxHeaders` + hidden input); `docs/contrib/auth.md` references it.

## Test plan

- [x] `mise run test` green
- [x] `mise run lint` clean (0 issues)
- [x] `mise run docs-build` clean (no unresolved links / parse warnings)
- [ ] Live WebAuthn smoke before next release tag (out of this PR's scope)