### PR TITLE
feat(server,ratelimit): adopt chi v5.3.0 ClientIP API framework-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ## Unreleased
 
+### Breaking Changes
+
+- **`--ratelimit-trust-proxy` removed.** Client-IP extraction now lives at server level via `--client-ip-mode`; ratelimit reads `burrow.ClientIP(r.Context())`. Migration depends on your proxy (Nginx, Cloudflare, AWS ALB, etc.) — see the [Client IP guide](https://burrow.andrich.dev/guide/client-ip/) for the right combination. The old behaviour matched Nginx with `ngx_http_realip_module` and is now `--client-ip-mode=header --client-ip-header=X-Real-IP`.
+
 ### Added
 
+- **Framework-wide client IP via chi v5.3.0's new `ClientIPFromX` API.** Four `--client-ip-mode` choices (`remote-addr`, `header`, `xff-trusted-proxies`, `xff-trusted-cidrs`), each with its companion flag — boot fails fast on missing/mismatched companions. `burrow.ClientIP(ctx)` and `burrow.ClientIPAddr(ctx)` expose the value to contribs without a chi import. ratelimit is the first consumer; future request-logging / geofencing / abuse-detection can read from the same source.
 - **contrib/auth: `<noscript>` fallback in the public auth layout.** Login/register/recovery pages render a translated noscript block so JS-off browsers see an explanation instead of a silently-broken passkey button. New i18n keys `auth-noscript-{title,body,link-text}` ship in English + German.
 
 ### Changed

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -44,7 +44,7 @@ Generated with [google/go-licenses](https://github.com/google/go-licenses).
 
 | Module | License | URL |
 |--------|---------|-----|
-| aead.dev/minisign | MIT | [LICENSE](Unknown) |
+| aead.dev/minisign | MIT | [LICENSE](https://github.com/aead/minisign/blob/v0.2.0/LICENSE) |
 | github.com/BurntSushi/toml | MIT | [LICENSE](https://github.com/BurntSushi/toml/blob/v1.6.0/COPYING) |
 | github.com/cloudflare/tableflip | BSD-3-Clause | [LICENSE](https://github.com/cloudflare/tableflip/blob/v1.2.3/LICENSE) |
 | github.com/davecgh/go-spew/spew | ISC | [LICENSE](https://github.com/davecgh/go-spew/blob/v1.1.1/LICENSE) |

--- a/app/config.go
+++ b/app/config.go
@@ -23,9 +23,29 @@ type ServerConfig struct {
 	BaseURL         string
 	PIDFile         string
 	AppName         string
+	ClientIP        ClientIPConfig
 	Port            int
 	MaxBodySize     int // in MB
 	ShutdownTimeout int // in seconds
+}
+
+// ClientIPConfig selects how the framework extracts the client IP from
+// incoming requests. Read the result via [burrow.ClientIP] /
+// [burrow.ClientIPAddr]. There is no safe default: each non-`remote-addr`
+// mode requires its own companion configuration so the operator picks the
+// trust source explicitly. See docs/guide/client-ip.md.
+type ClientIPConfig struct {
+	// Mode is one of: "remote-addr" (default), "header",
+	// "xff-trusted-proxies", "xff-trusted-cidrs".
+	Mode string
+	// Header is the trusted single-IP header (mode=header).
+	Header string
+	// TrustedCIDRs is the list of CIDR prefixes covering the trusted
+	// proxy fleet (mode=xff-trusted-cidrs).
+	TrustedCIDRs []string
+	// TrustedProxies is the number of trusted hops to walk back through
+	// X-Forwarded-For (mode=xff-trusted-proxies).
+	TrustedProxies int
 }
 
 // resolveAppName returns the explicit flag value when set, falling back to
@@ -83,6 +103,12 @@ func NewConfig(cmd *cli.Command) *Config {
 			AppName:         resolveAppName(cmd.String("app-name")),
 			MaxBodySize:     int(cmd.Int("max-body-size")),
 			ShutdownTimeout: int(cmd.Int("shutdown-timeout")),
+			ClientIP: ClientIPConfig{
+				Mode:           cmd.String("client-ip-mode"),
+				Header:         cmd.String("client-ip-header"),
+				TrustedProxies: int(cmd.Int("client-ip-trusted-proxies")),
+				TrustedCIDRs:   splitCSV(cmd.String("client-ip-trusted-cidrs")),
+			},
 		},
 		Database: DatabaseConfig{
 			DSN: cmd.String("database-dsn"),
@@ -130,6 +156,70 @@ func (c *Config) ResolveBaseURL() string {
 		return fmt.Sprintf("%s://%s", scheme, host)
 	}
 	return fmt.Sprintf("%s://%s:%d", scheme, host, port)
+}
+
+// splitCSV splits a comma-separated string and trims surrounding whitespace
+// from each entry, returning nil for an empty input. Used for flag values
+// that accept a list (e.g. --client-ip-trusted-cidrs).
+func splitCSV(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// ValidateClientIP checks that the client-IP configuration is consistent.
+// Each non-default mode requires its companion flag; setting a companion
+// flag without the matching mode is rejected so misconfigurations fail at
+// boot rather than silently picking the wrong source. See
+// docs/guide/client-ip.md for the trust-model rationale.
+func (c *Config) ValidateClientIP(_ *cli.Command) error {
+	cip := c.Server.ClientIP
+	switch cip.Mode {
+	case "", "remote-addr":
+		return rejectClientIPCompanions(cip, "")
+	case "header":
+		if cip.Header == "" {
+			return fmt.Errorf("--client-ip-mode=header requires --client-ip-header (e.g. X-Real-IP, CF-Connecting-IP)")
+		}
+		return rejectClientIPCompanions(cip, "header")
+	case "xff-trusted-proxies":
+		if cip.TrustedProxies <= 0 {
+			return fmt.Errorf("--client-ip-mode=xff-trusted-proxies requires --client-ip-trusted-proxies > 0")
+		}
+		return rejectClientIPCompanions(cip, "trusted-proxies")
+	case "xff-trusted-cidrs":
+		if len(cip.TrustedCIDRs) == 0 {
+			return fmt.Errorf("--client-ip-mode=xff-trusted-cidrs requires --client-ip-trusted-cidrs (comma-separated CIDRs)")
+		}
+		return rejectClientIPCompanions(cip, "trusted-cidrs")
+	default:
+		return fmt.Errorf("unknown client-ip mode: %q (valid: remote-addr, header, xff-trusted-proxies, xff-trusted-cidrs)", cip.Mode)
+	}
+}
+
+// rejectClientIPCompanions errors out if any companion flag *other* than the
+// one whitelisted by allow is set. allow == "" rejects every companion (the
+// remote-addr case). This pins the design promise that a misplaced companion
+// flag is a hard error, not a silent no-op.
+func rejectClientIPCompanions(cip ClientIPConfig, allow string) error {
+	if cip.Header != "" && allow != "header" {
+		return fmt.Errorf("--client-ip-header is only valid with --client-ip-mode=header")
+	}
+	if cip.TrustedProxies != 0 && allow != "trusted-proxies" {
+		return fmt.Errorf("--client-ip-trusted-proxies is only valid with --client-ip-mode=xff-trusted-proxies")
+	}
+	if len(cip.TrustedCIDRs) != 0 && allow != "trusted-cidrs" {
+		return fmt.Errorf("--client-ip-trusted-cidrs is only valid with --client-ip-mode=xff-trusted-cidrs")
+	}
+	return nil
 }
 
 // ValidateTLS checks that the TLS configuration is consistent.
@@ -247,6 +337,27 @@ func CoreFlags(configSource func(key string) cli.ValueSource) []cli.Flag {
 			Value:   10,
 			Usage:   "Graceful shutdown timeout in seconds",
 			Sources: FlagSources(configSource, "SHUTDOWN_TIMEOUT", "server.shutdown_timeout"),
+		},
+		&cli.StringFlag{
+			Name:    "client-ip-mode",
+			Value:   "remote-addr",
+			Usage:   "Source of the client IP. One of: remote-addr (no proxy), header (single trusted header), xff-trusted-proxies (count of hops), xff-trusted-cidrs (CIDR list). See docs/guide/client-ip.md.",
+			Sources: FlagSources(configSource, "CLIENT_IP_MODE", "server.client_ip.mode"),
+		},
+		&cli.StringFlag{
+			Name:    "client-ip-header",
+			Usage:   "Trusted single-IP header (with --client-ip-mode=header): e.g. X-Real-IP for Nginx ngx_http_realip_module, CF-Connecting-IP for Cloudflare.",
+			Sources: FlagSources(configSource, "CLIENT_IP_HEADER", "server.client_ip.header"),
+		},
+		&cli.IntFlag{
+			Name:    "client-ip-trusted-proxies",
+			Usage:   "Number of trusted reverse-proxy hops in X-Forwarded-For (with --client-ip-mode=xff-trusted-proxies). Use when proxy IPs are dynamic.",
+			Sources: FlagSources(configSource, "CLIENT_IP_TRUSTED_PROXIES", "server.client_ip.trusted_proxies"),
+		},
+		&cli.StringFlag{
+			Name:    "client-ip-trusted-cidrs",
+			Usage:   "Comma-separated CIDRs covering the trusted proxy fleet (with --client-ip-mode=xff-trusted-cidrs): e.g. 13.32.0.0/15,52.46.0.0/18.",
+			Sources: FlagSources(configSource, "CLIENT_IP_TRUSTED_CIDRS", "server.client_ip.trusted_cidrs"),
 		},
 		&cli.StringFlag{
 			Name:    "database-dsn",

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -18,6 +18,7 @@ func TestCoreFlags(t *testing.T) {
 
 	expected := []string{
 		"host", "port", "base-url", "pid-file", "max-body-size", "shutdown-timeout",
+		"client-ip-mode", "client-ip-header", "client-ip-trusted-proxies", "client-ip-trusted-cidrs",
 		"database-dsn",
 		"storage-dsn",
 		"tls-mode", "tls-cert-dir", "tls-email", "tls-cert-file", "tls-key-file",
@@ -157,6 +158,132 @@ func TestValidateTLS_UnknownMode(t *testing.T) {
 	err := cfg.ValidateTLS(cmd)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown TLS mode")
+}
+
+func TestClientIP_DefaultMode(t *testing.T) {
+	cmd := runCommand(t)
+	cfg := NewConfig(cmd)
+	assert.Equal(t, "remote-addr", cfg.Server.ClientIP.Mode)
+	assert.Empty(t, cfg.Server.ClientIP.Header)
+	assert.Zero(t, cfg.Server.ClientIP.TrustedProxies)
+	assert.Empty(t, cfg.Server.ClientIP.TrustedCIDRs)
+
+	require.NoError(t, cfg.ValidateClientIP(cmd))
+}
+
+func TestClientIP_HeaderMode(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "header", "--client-ip-header", "X-Real-IP")
+	cfg := NewConfig(cmd)
+	assert.Equal(t, "header", cfg.Server.ClientIP.Mode)
+	assert.Equal(t, "X-Real-IP", cfg.Server.ClientIP.Header)
+
+	require.NoError(t, cfg.ValidateClientIP(cmd))
+}
+
+func TestValidateClientIP_HeaderModeMissingHeader(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "header")
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-header")
+}
+
+func TestValidateClientIP_XFFTrustedProxiesMode(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "xff-trusted-proxies", "--client-ip-trusted-proxies", "2")
+	cfg := NewConfig(cmd)
+	assert.Equal(t, "xff-trusted-proxies", cfg.Server.ClientIP.Mode)
+	assert.Equal(t, 2, cfg.Server.ClientIP.TrustedProxies)
+
+	require.NoError(t, cfg.ValidateClientIP(cmd))
+}
+
+func TestValidateClientIP_XFFTrustedProxiesMissingCount(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "xff-trusted-proxies")
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-trusted-proxies")
+}
+
+func TestValidateClientIP_XFFTrustedCIDRsMode(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "xff-trusted-cidrs", "--client-ip-trusted-cidrs", "13.32.0.0/15,52.46.0.0/18")
+	cfg := NewConfig(cmd)
+	assert.Equal(t, "xff-trusted-cidrs", cfg.Server.ClientIP.Mode)
+	assert.Equal(t, []string{"13.32.0.0/15", "52.46.0.0/18"}, cfg.Server.ClientIP.TrustedCIDRs)
+
+	require.NoError(t, cfg.ValidateClientIP(cmd))
+}
+
+func TestValidateClientIP_XFFTrustedCIDRsMissingList(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "xff-trusted-cidrs")
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-trusted-cidrs")
+}
+
+func TestValidateClientIP_UnknownMode(t *testing.T) {
+	cmd := runCommand(t, "--client-ip-mode", "bogus")
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown client-ip mode")
+}
+
+func TestValidateClientIP_HeaderSetWithWrongMode(t *testing.T) {
+	// Companion flag set without the matching mode is a configuration
+	// error — fail fast instead of silently ignoring the flag.
+	cmd := runCommand(t, "--client-ip-mode", "remote-addr", "--client-ip-header", "X-Real-IP")
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-header")
+}
+
+func TestValidateClientIP_HeaderModeRejectsTrustedProxies(t *testing.T) {
+	// Cross-mode companion: --client-ip-mode=header with --client-ip-trusted-proxies
+	// is meaningless — chi's ClientIPFromHeader ignores XFF. Fail at boot.
+	cmd := runCommand(t,
+		"--client-ip-mode", "header",
+		"--client-ip-header", "X-Real-IP",
+		"--client-ip-trusted-proxies", "2",
+	)
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-trusted-proxies")
+}
+
+func TestValidateClientIP_XFFTrustedProxiesRejectsCIDRs(t *testing.T) {
+	cmd := runCommand(t,
+		"--client-ip-mode", "xff-trusted-proxies",
+		"--client-ip-trusted-proxies", "2",
+		"--client-ip-trusted-cidrs", "10.0.0.0/8",
+	)
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-trusted-cidrs")
+}
+
+func TestValidateClientIP_XFFTrustedCIDRsRejectsHeader(t *testing.T) {
+	cmd := runCommand(t,
+		"--client-ip-mode", "xff-trusted-cidrs",
+		"--client-ip-trusted-cidrs", "10.0.0.0/8",
+		"--client-ip-header", "X-Real-IP",
+	)
+	cfg := NewConfig(cmd)
+
+	err := cfg.ValidateClientIP(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--client-ip-header")
 }
 
 func TestFlagSourcesWithNilConfigSource(t *testing.T) {

--- a/burrow_test.go
+++ b/burrow_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -117,6 +119,39 @@ func TestContextHelpers_RoundTrip(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "value", got)
 	})
+}
+
+func TestClientIP_RoundTripThroughChiMiddleware(t *testing.T) {
+	// burrow.ClientIP and burrow.ClientIPAddr re-export chi's GetClientIP /
+	// GetClientIPAddr so contribs can read the framework-wide source of
+	// client IP without importing chi/v5/middleware directly. Verify the
+	// re-export by running a real chi middleware in front of a handler that
+	// reads through the burrow facade.
+	r := chi.NewRouter()
+	r.Use(chimw.ClientIPFromHeader("X-Real-IP"))
+	var typedAddrValid bool
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		typedAddrValid = burrow.ClientIPAddr(req.Context()).IsValid()
+		_, _ = w.Write([]byte(burrow.ClientIP(req.Context())))
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, "198.51.100.7", rec.Body.String(),
+		"burrow.ClientIP must return the value chi's ClientIPFromHeader middleware stored")
+	assert.True(t, typedAddrValid, "burrow.ClientIPAddr must also be populated by chi's middleware")
+}
+
+func TestClientIP_EmptyWhenNoMiddleware(t *testing.T) {
+	// Without chi's ClientIP middleware in the chain, burrow.ClientIP should
+	// return the zero value — contribs depending on it must implement a
+	// fallback (ratelimit does, via r.RemoteAddr).
+	ctx := context.Background()
+	assert.Empty(t, burrow.ClientIP(ctx))
+	assert.False(t, burrow.ClientIPAddr(ctx).IsValid())
 }
 
 func TestAuthHelpers_NoChecker_ReturnFalse(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -2,7 +2,9 @@ package burrow
 
 import (
 	"context"
+	"net/netip"
 
+	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/oliverandrich/burrow/app"
 )
 
@@ -82,3 +84,13 @@ func WithContextValue(ctx context.Context, key, val any) context.Context {
 func ContextValue[T any](ctx context.Context, key any) (T, bool) {
 	return app.ContextValue[T](ctx, key)
 }
+
+// ClientIP returns the client IP stored in the context by burrow's
+// server-level ClientIP middleware (configured via --client-ip-mode). Returns
+// "" when no middleware ran. Wrapper around [chimw.GetClientIP]. See
+// docs/guide/client-ip.md for the trust model.
+func ClientIP(ctx context.Context) string { return chimw.GetClientIP(ctx) }
+
+// ClientIPAddr returns the client IP as a [netip.Addr]. Use [netip.Addr.IsValid]
+// to check whether a middleware ran. Wrapper around [chimw.GetClientIPAddr].
+func ClientIPAddr(ctx context.Context) netip.Addr { return chimw.GetClientIPAddr(ctx) }

--- a/contrib/ratelimit/app.go
+++ b/contrib/ratelimit/app.go
@@ -66,11 +66,6 @@ func (a *App) Flags(configSource func(key string) cli.ValueSource) []cli.Flag {
 			Usage:   "Interval for sweeping expired rate limit entries",
 			Sources: burrow.FlagSources(configSource, "RATELIMIT_CLEANUP_INTERVAL", "ratelimit.cleanup_interval"),
 		},
-		&cli.BoolFlag{
-			Name:    "ratelimit-trust-proxy",
-			Usage:   "Use X-Real-IP header for client IP extraction",
-			Sources: burrow.FlagSources(configSource, "RATELIMIT_TRUST_PROXY", "ratelimit.trust_proxy"),
-		},
 		&cli.IntFlag{
 			Name:    "ratelimit-max-clients",
 			Value:   10000,
@@ -83,25 +78,24 @@ func (a *App) Flags(configSource func(key string) cli.ValueSource) []cli.Flag {
 func (a *App) Configure(_ *burrow.AppConfig, cmd *cli.Command) error {
 	rps := cmd.Float("ratelimit-rate")
 	burst := int(cmd.Int("ratelimit-burst"))
-	trustProxy := cmd.Bool("ratelimit-trust-proxy")
 	cleanupInterval := cmd.Duration("ratelimit-cleanup-interval")
 	maxClients := int(cmd.Int("ratelimit-max-clients"))
 
-	return a.configureWithCleanup(rps, burst, trustProxy, cleanupInterval, maxClients)
+	return a.configureWithCleanup(rps, burst, cleanupInterval, maxClients)
 }
 
 // configure sets up the limiter with default cleanup interval.
 // Used by tests that don't need a cli.Command.
-func (a *App) configure(rps float64, burst int, trustProxy bool) {
-	_ = a.configureWithCleanup(rps, burst, trustProxy, time.Minute, 0)
+func (a *App) configure(rps float64, burst int) {
+	_ = a.configureWithCleanup(rps, burst, time.Minute, 0)
 }
 
-func (a *App) configureWithCleanup(rps float64, burst int, trustProxy bool, cleanupInterval time.Duration, maxClients int) error {
+func (a *App) configureWithCleanup(rps float64, burst int, cleanupInterval time.Duration, maxClients int) error {
 	if err := validateConfig(rps, burst, cleanupInterval, maxClients); err != nil {
 		return err
 	}
 	if a.keyFunc == nil {
-		a.keyFunc = defaultKeyFunc(trustProxy)
+		a.keyFunc = defaultKeyFunc
 	}
 	a.limiter = NewLimiter(rps, burst, cleanupInterval, maxClients)
 	return nil

--- a/contrib/ratelimit/app_test.go
+++ b/contrib/ratelimit/app_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/oliverandrich/burrow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ func TestName(t *testing.T) {
 func newTestApp(t *testing.T, rps float64, burst int) *App {
 	t.Helper()
 	a := New()
-	a.configure(rps, burst, false)
+	a.configure(rps, burst)
 	t.Cleanup(func() { a.Shutdown(t.Context()) })
 	return a
 }
@@ -128,9 +129,50 @@ func TestMiddleware_DifferentIPsIndependent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
-func TestMiddleware_TrustProxy(t *testing.T) {
-	a := New(WithKeyFunc(defaultKeyFunc(true)))
-	a.configure(1, 1, true)
+func TestMiddleware_ReadsClientIPFromContext(t *testing.T) {
+	// When burrow's server-level ClientIP middleware runs in front of
+	// ratelimit, the rate-limit key is derived from the framework-wide
+	// client IP rather than r.RemoteAddr. Verify by wiring chi's
+	// ClientIPFromHeader in front and checking that two requests sharing
+	// an X-Real-IP value are rate-limited together regardless of
+	// RemoteAddr.
+	a := New()
+	a.configure(1, 1)
+	t.Cleanup(func() { a.Shutdown(t.Context()) })
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := chimw.ClientIPFromHeader("X-Real-IP")(a.Middleware()[0](inner))
+
+	// First request: different RemoteAddr, same X-Real-IP.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Real-IP", "203.0.113.1")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Second request: yet another RemoteAddr but the same X-Real-IP. If
+	// the key came from RemoteAddr this would pass; from the framework
+	// client IP, it gets denied.
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.2:1234"
+	req.Header.Set("X-Real-IP", "203.0.113.1")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusTooManyRequests, rr.Code,
+		"ratelimit must derive its key from burrow.ClientIP, not r.RemoteAddr")
+}
+
+func TestMiddleware_FallsBackToRemoteAddrWithoutClientIPMiddleware(t *testing.T) {
+	// When no ClientIP middleware ran (downstream app mounted ratelimit
+	// without the burrow server, or a unit test exercises this contrib in
+	// isolation), defaultKeyFunc falls back to the host portion of
+	// r.RemoteAddr so rate limiting still functions.
+	a := New()
+	a.configure(1, 1)
 	t.Cleanup(func() { a.Shutdown(t.Context()) })
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -139,28 +181,25 @@ func TestMiddleware_TrustProxy(t *testing.T) {
 
 	handler := a.Middleware()[0](inner)
 
-	// First request from proxy with X-Real-IP.
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
-	req.RemoteAddr = "10.0.0.1:1234"
-	req.Header.Set("X-Real-IP", "203.0.113.1")
+	req.RemoteAddr = "1.2.3.4:5678"
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	// Second request from same real IP — should be denied.
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
-	req.RemoteAddr = "10.0.0.1:1234"
-	req.Header.Set("X-Real-IP", "203.0.113.1")
+	req.RemoteAddr = "1.2.3.4:5679" // same host, different port
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+	assert.Equal(t, http.StatusTooManyRequests, rr.Code,
+		"fallback should use the host portion only so ephemeral ports don't bypass the limit")
 }
 
 func TestMiddleware_CustomKeyFunc(t *testing.T) {
 	a := New(WithKeyFunc(func(r *http.Request) string {
 		return r.Header.Get("X-API-Key")
 	}))
-	a.configure(1, 1, false)
+	a.configure(1, 1)
 	t.Cleanup(func() { a.Shutdown(t.Context()) })
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -191,7 +230,7 @@ func TestMiddleware_CustomOnLimited(t *testing.T) {
 		customCalled = true
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
-	a.configure(1, 1, false)
+	a.configure(1, 1)
 	t.Cleanup(func() { a.Shutdown(t.Context()) })
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -264,7 +303,7 @@ func TestConfigureWithCleanup_InvalidValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := New()
-			err := a.configureWithCleanup(tt.rps, tt.burst, false, tt.cleanupInterval, tt.maxClients)
+			err := a.configureWithCleanup(tt.rps, tt.burst, tt.cleanupInterval, tt.maxClients)
 			assert.Error(t, err)
 		})
 	}
@@ -272,7 +311,7 @@ func TestConfigureWithCleanup_InvalidValues(t *testing.T) {
 
 func TestConfigureWithCleanup_ValidValues(t *testing.T) {
 	a := New()
-	err := a.configureWithCleanup(10, 5, false, time.Minute, 0)
+	err := a.configureWithCleanup(10, 5, time.Minute, 0)
 	require.NoError(t, err)
 	assert.NotNil(t, a.limiter)
 	a.Shutdown(t.Context())

--- a/contrib/ratelimit/middleware.go
+++ b/contrib/ratelimit/middleware.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"net"
 	"net/http"
+
+	"github.com/oliverandrich/burrow"
 )
 
 func (a *App) rateLimitMiddleware(next http.Handler) http.Handler {
@@ -27,29 +29,20 @@ func (a *App) rateLimitMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// defaultKeyFunc extracts the client IP from the request.
-// If trustProxy is true, it uses the X-Real-IP header set by the reverse proxy.
-// X-Forwarded-For is intentionally not used because it can contain multiple
-// comma-separated values that are trivially spoofed to bypass rate limiting.
-//
-// WARNING: trustProxy must only be enabled when the application runs behind a
-// reverse proxy (nginx, Caddy, etc.) that sets the X-Real-IP header and strips
-// any client-supplied value. Without a proxy, clients can spoof X-Real-IP to
-// bypass rate limiting entirely.
-func defaultKeyFunc(trustProxy bool) func(*http.Request) string {
-	return func(r *http.Request) string {
-		if trustProxy {
-			if xri := r.Header.Get("X-Real-IP"); xri != "" {
-				return xri
-			}
-		}
-
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			return r.RemoteAddr
-		}
-		return host
+// defaultKeyFunc derives the rate-limit key from the framework-wide client
+// IP set by burrow's server-level ClientIP middleware (configured via
+// --client-ip-mode; see docs/guide/client-ip.md). Falls back to the host
+// portion of RemoteAddr when the middleware did not run — e.g. in unit tests
+// that exercise this contrib in isolation.
+func defaultKeyFunc(r *http.Request) string {
+	if ip := burrow.ClientIP(r.Context()); ip != "" {
+		return ip
 	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }
 
 // defaultOnLimited sends a plain text 429 response.

--- a/docs/contrib/ratelimit.md
+++ b/docs/contrib/ratelimit.md
@@ -43,24 +43,20 @@ Idle client entries are automatically cleaned up at the configured interval.
 
 ## Client Identification
 
-By default, the client IP is extracted from `RemoteAddr`. When `--ratelimit-trust-proxy` is enabled, the middleware uses the `X-Real-IP` header instead.
+The rate-limit key is derived from `burrow.ClientIP(r.Context())` — the framework-wide client IP set by the server-level `--client-ip-mode` middleware. Without that middleware (downstream apps mounting ratelimit in isolation, unit tests), the key falls back to the host portion of `r.RemoteAddr` (e.g. `"1.2.3.4:5678"` → `"1.2.3.4"`).
 
-Configure your reverse proxy to set `X-Real-IP` to the actual client IP:
+To rate-limit by the actual end-user IP rather than the proxy's, pick the matching client-IP mode at server level. See [Client IP](../guide/client-ip.md) for the full decision tree:
 
-```nginx
-# nginx
-proxy_set_header X-Real-IP $remote_addr;
+```bash
+# Cloudflare
+--client-ip-mode=header --client-ip-header=CF-Connecting-IP
+
+# Nginx with ngx_http_realip_module
+--client-ip-mode=header --client-ip-header=X-Real-IP
+
+# AWS ALB / dynamic proxy fleet, 2 hops
+--client-ip-mode=xff-trusted-proxies --client-ip-trusted-proxies=2
 ```
-
-```
-# Caddy (sets X-Real-IP automatically)
-```
-
-!!! warning
-    Without `--ratelimit-trust-proxy`, all traffic behind a reverse proxy appears to come from the proxy's IP — effectively rate limiting all clients as one. With the flag enabled but no `X-Real-IP` header set, the middleware falls back to `RemoteAddr`.
-
-!!! danger "Security: never enable trust-proxy without a reverse proxy"
-    When `--ratelimit-trust-proxy` is enabled, clients can spoof the `X-Real-IP` header to bypass rate limiting entirely. Only enable this flag when your application runs behind a reverse proxy (nginx, Caddy, etc.) that overwrites `X-Real-IP` with the actual client IP on every request.
 
 Override with `WithKeyFunc()` for custom identification (e.g., by API key or authenticated user).
 
@@ -83,8 +79,9 @@ This is useful in custom `OnLimited` handlers.
 | `--ratelimit-rate` | `RATELIMIT_RATE` | `10` | Requests per second (token refill rate) |
 | `--ratelimit-burst` | `RATELIMIT_BURST` | `20` | Maximum burst size (bucket capacity) |
 | `--ratelimit-cleanup-interval` | `RATELIMIT_CLEANUP_INTERVAL` | `1m` | Interval for sweeping expired entries |
-| `--ratelimit-trust-proxy` | `RATELIMIT_TRUST_PROXY` | `false` | Use `X-Real-IP` header for client IP |
 | `--ratelimit-max-clients` | `RATELIMIT_MAX_CLIENTS` | `10000` | Maximum tracked clients (0 = unlimited) |
+
+Client-IP extraction is configured at server level via `--client-ip-mode` — see [Client IP](../guide/client-ip.md).
 
 ## Graceful Shutdown
 
@@ -95,6 +92,6 @@ The rate limiter implements `HasShutdown` to stop the background cleanup gorouti
 | Interface | Description |
 |-----------|-------------|
 | `burrow.App` | Required: `Name()` |
-| `Configurable` | Rate, burst, cleanup interval, and trust-proxy flags |
+| `Configurable` | Rate, burst, cleanup interval, max-clients flags |
 | `HasMiddleware` | Rate limiting middleware |
 | `HasShutdown` | Stops the cleanup goroutine |

--- a/docs/guide/client-ip.md
+++ b/docs/guide/client-ip.md
@@ -1,0 +1,75 @@
+# Client IP
+
+burrow exposes the client IP framework-wide so contribs (rate limiting today; request logging, geofencing, abuse detection tomorrow) read a single source instead of each rolling their own header parser.
+
+!!! info "Upgrading from `--ratelimit-trust-proxy`?"
+    The flag is removed. Jump to [Migration](#migration-from-the-old-ratelimit-trust-proxy-flag) — the right replacement depends on your proxy (Cloudflare, Nginx, AWS, etc.), so don't just guess `X-Real-IP`.
+
+## The trust problem
+
+There is no safe default for "what's the client IP." `r.RemoteAddr` is the TCP peer, which is the client if you're directly on the internet and the reverse proxy otherwise. Headers like `X-Forwarded-For` are useful behind known proxies and trivially spoofable everywhere else. Quoting [chi v5.3.0's release notes](https://github.com/go-chi/chi/releases/tag/v5.3.0):
+
+> There is no safe default — the user must pick their trust source explicitly.
+
+burrow takes that stance literally: `--client-ip-mode` is a required choice, and every non-default mode demands its companion flag.
+
+## Picking a mode
+
+| Deployment | Mode | Companion |
+|---|---|---|
+| No proxy / server directly on the internet | `remote-addr` (default) | — |
+| Cloudflare | `header` | `--client-ip-header=CF-Connecting-IP` |
+| Nginx with `ngx_http_realip_module` | `header` | `--client-ip-header=X-Real-IP` |
+| Apache with `mod_remoteip` | `header` | `--client-ip-header=X-Client-IP` |
+| Known proxy CIDRs (AWS CloudFront, etc.) | `xff-trusted-cidrs` | `--client-ip-trusted-cidrs=13.32.0.0/15,52.46.0.0/18` |
+| Dynamic proxy fleet (autoscaling, ephemeral) | `xff-trusted-proxies` | `--client-ip-trusted-proxies=2` |
+
+`header` mode is safe only when your proxy **unconditionally overwrites** the named header on every request. `True-Client-IP`, `X-Azure-ClientIP`, and `Fastly-Client-IP` look similar but pass client-supplied values through by default in those products — don't use them unless your edge strips the inbound value first.
+
+!!! danger "Trust boundary for header-mode CDNs (Cloudflare, etc.)"
+    `--client-ip-header=CF-Connecting-IP` is correct only when burrow accepts connections **exclusively** from Cloudflare's edge — either via a firewall restricting inbound traffic to [Cloudflare's IP ranges](https://www.cloudflare.com/ips/), via [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) (`cloudflared`), or behind a private network. If your origin is reachable on the public internet, anyone hitting it directly can forge `CF-Connecting-IP` and burrow has no way to tell. The same logic applies to any header-mode CDN.
+
+`xff-trusted-proxies` is brittle: if you add or remove a proxy hop and forget to update the count, you'll silently start trusting an attacker-supplied IP. Prefer `xff-trusted-cidrs` whenever you can enumerate the proxy IP ranges.
+
+## Reading the result
+
+In handlers and middleware:
+
+```go
+import "github.com/oliverandrich/burrow"
+
+func handler(w http.ResponseWriter, r *http.Request) error {
+    ip := burrow.ClientIP(r.Context())   // string; "" if no middleware ran
+    addr := burrow.ClientIPAddr(r.Context()) // netip.Addr; check addr.IsValid()
+    // log, rate-limit, geo-lookup, etc.
+}
+```
+
+`burrow.ClientIP` and `burrow.ClientIPAddr` re-export chi's `GetClientIP` / `GetClientIPAddr`, so the framework's source of client IP is the same one chi's middleware populates.
+
+## Configuration
+
+All four flags accept env-var and TOML sources (consistent with every other burrow flag):
+
+```toml
+# burrow.toml
+[server.client_ip]
+mode = "header"
+header = "X-Real-IP"
+
+# Or, for a dynamic AWS ALB fleet:
+# mode = "xff-trusted-proxies"
+# trusted_proxies = 2
+```
+
+Boot fails fast on misconfiguration: setting a companion flag without the matching mode (or selecting a mode without its companion) returns an error from `boot` rather than silently picking an unintended source.
+
+## Migration from the old ratelimit-trust-proxy flag
+
+`--ratelimit-trust-proxy` (removed) was equivalent to:
+
+```
+--client-ip-mode=header --client-ip-header=X-Real-IP
+```
+
+Update your config; `contrib/ratelimit` now derives its rate-limit key from `burrow.ClientIP` regardless of which mode you pick.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
           - Building Releases: guide/releases.md
           - Logging: guide/logging.md
           - TLS: guide/tls.md
+          - Client IP: guide/client-ip.md
   - Tutorial:
       - Overview: tutorial/index.md
       - "Part 1: Setup & First View": tutorial/part1.md

--- a/server/clientip.go
+++ b/server/clientip.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"net/http"
+
+	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/oliverandrich/burrow/app"
+)
+
+// clientIPMiddleware returns the chi middleware that matches the configured
+// mode. The caller is expected to have invoked [app.Config.ValidateClientIP]
+// first; an unrecognised mode falls back to remote-addr.
+//
+// Mode-to-middleware mapping (see docs/guide/client-ip.md):
+//
+//   - remote-addr           → [chimw.ClientIPFromRemoteAddr] — TCP peer IP only,
+//     correct when this server is directly on the public internet.
+//   - header                → [chimw.ClientIPFromHeader](cfg.Header) — trust the
+//     single-IP header the reverse proxy unconditionally overwrites.
+//   - xff-trusted-proxies   → [chimw.ClientIPFromXFFTrustedProxies](cfg.TrustedProxies) —
+//     walk back the configured number of hops in X-Forwarded-For.
+//   - xff-trusted-cidrs     → [chimw.ClientIPFromXFF](cfg.TrustedCIDRs...) — walk
+//     back X-Forwarded-For skipping IPs in the trusted CIDR set.
+func clientIPMiddleware(cfg app.ClientIPConfig) func(http.Handler) http.Handler {
+	switch cfg.Mode {
+	case "header":
+		return chimw.ClientIPFromHeader(cfg.Header)
+	case "xff-trusted-proxies":
+		return chimw.ClientIPFromXFFTrustedProxies(cfg.TrustedProxies)
+	case "xff-trusted-cidrs":
+		return chimw.ClientIPFromXFF(cfg.TrustedCIDRs...)
+	default:
+		return chimw.ClientIPFromRemoteAddr
+	}
+}

--- a/server/clientip_test.go
+++ b/server/clientip_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chimw "github.com/go-chi/chi/v5/middleware"
+	"github.com/oliverandrich/burrow/app"
+	"github.com/stretchr/testify/assert"
+)
+
+// runWithClientIPMiddleware exercises the dispatch helper end-to-end:
+// wraps a handler with clientIPMiddleware(cfg), fires req, returns the
+// client IP chi stored in the context (via chimw.GetClientIP). The handler
+// also captures whatever was set so the test can assert on it.
+func runWithClientIPMiddleware(t *testing.T, cfg app.ClientIPConfig, req *http.Request) string {
+	t.Helper()
+	var got string
+	h := clientIPMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = chimw.GetClientIP(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return got
+}
+
+func TestClientIPMiddleware_RemoteAddr(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:54321"
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{Mode: "remote-addr"}, req)
+	assert.Equal(t, "203.0.113.5", got)
+}
+
+func TestClientIPMiddleware_RemoteAddr_DefaultModeEmpty(t *testing.T) {
+	// Mode == "" should behave the same as remote-addr (default path).
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:54321"
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{}, req)
+	assert.Equal(t, "203.0.113.5", got)
+}
+
+func TestClientIPMiddleware_Header(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:443" // proxy
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{
+		Mode:   "header",
+		Header: "X-Real-IP",
+	}, req)
+	assert.Equal(t, "198.51.100.7", got, "header mode should ignore RemoteAddr and trust the configured header")
+}
+
+func TestClientIPMiddleware_Header_Cloudflare(t *testing.T) {
+	// Same mechanism, different header name — confirms the header is wired
+	// from config rather than hardcoded.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:443"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.8")
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{
+		Mode:   "header",
+		Header: "CF-Connecting-IP",
+	}, req)
+	assert.Equal(t, "198.51.100.8", got)
+}
+
+func TestClientIPMiddleware_XFFTrustedProxies(t *testing.T) {
+	// Topology: Client (203.0.113.5) → TrustedProxy1 → TrustedProxy2 → us.
+	// As-received XFF is "203.0.113.5, 10.0.0.1" (TrustedProxy2 appended
+	// TrustedProxy1's IP). With numTrusted=2 chi returns
+	// xff[len-2] = xff[0] = the client. A spoofed entry the client prepends
+	// (simulated below by adding an evil first entry) sits OUTSIDE the
+	// trusted zone and is correctly ignored.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:443"
+	req.Header.Set("X-Forwarded-For", "192.0.2.99, 203.0.113.5, 10.0.0.1")
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{
+		Mode:           "xff-trusted-proxies",
+		TrustedProxies: 2,
+	}, req)
+	assert.Equal(t, "203.0.113.5", got,
+		"with 2 trusted proxies and a spoofed leading entry, chi must return position len(xff)-numTrusted")
+}
+
+func TestClientIPMiddleware_XFFTrustedCIDRs(t *testing.T) {
+	// Trusted proxy CIDR covers 198.51.100.0/24; the first non-trusted IP
+	// walking right-to-left is the client.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "198.51.100.50:443"
+	req.Header.Set("X-Forwarded-For", "203.0.113.5, 198.51.100.51")
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{
+		Mode:         "xff-trusted-cidrs",
+		TrustedCIDRs: []string{"198.51.100.0/24"},
+	}, req)
+	assert.Equal(t, "203.0.113.5", got)
+}
+
+func TestClientIPMiddleware_UnknownMode_FallsBackToRemoteAddr(t *testing.T) {
+	// Validation should prevent this in practice, but the dispatcher must
+	// not panic — it falls back to the safest mode.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.5:54321"
+
+	got := runWithClientIPMiddleware(t, app.ClientIPConfig{Mode: "bogus"}, req)
+	assert.Equal(t, "203.0.113.5", got)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -211,6 +211,7 @@ func (s *Server) Run(ctx context.Context, cmd *cli.Command) error {
 		RecoverPanics: true,
 	}))
 	r.Use(chimw.RequestID)
+	r.Use(clientIPMiddleware(cfg.Server.ClientIP))
 	r.Use(chimw.Compress(5))
 	r.Use(chimw.RequestSize(int64(cfg.Server.MaxBodySize) * 1024 * 1024))
 	r.Use(s.i18nBundle.LocaleMiddleware())
@@ -273,6 +274,10 @@ func (s *Server) boot(ctx context.Context, cmd *cli.Command) (*burrowapp.Config,
 	cfg := burrowapp.NewConfig(cmd)
 
 	if err := cfg.ValidateTLS(cmd); err != nil {
+		return nil, nil, err
+	}
+
+	if err := cfg.ValidateClientIP(cmd); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
## Summary

chi v5.3.0 ships `ClientIPFromHeader/FromXFF/FromXFFTrustedProxies/FromRemoteAddr` to replace the deprecated `RealIP` middleware (three security advisories on header spoofing). burrow doesn't use `RealIP` so the deprecation doesn't force action — but adopting the new API now consolidates client-IP extraction onto chi's "no safe default, pick explicitly" model and gives future contribs (request logging, geofencing, abuse detection) a single source.

- **Server-level**: new `--client-ip-mode` flag picks one of `remote-addr` (default), `header`, `xff-trusted-proxies`, `xff-trusted-cidrs`. Each non-default mode requires its companion (`--client-ip-header`, `--client-ip-trusted-proxies`, `--client-ip-trusted-cidrs`). Boot fails fast on missing or mismatched companions. The matching chi middleware sits between `RequestID` and `Compress` so every downstream consumer can read the IP.
- **Facade**: `burrow.ClientIP(ctx) string` and `burrow.ClientIPAddr(ctx) netip.Addr` re-export chi's accessors. Contribs depend on burrow, not on `chi/v5/middleware` directly.
- **contrib/ratelimit (breaking)**: `--ratelimit-trust-proxy` removed. `defaultKeyFunc` reads `burrow.ClientIP(r.Context())` with a `net.SplitHostPort(r.RemoteAddr)` fallback so the contrib still works when mounted in isolation (downstream tests, opt-out apps).
- **Docs**: new `docs/guide/client-ip.md` decision tree (Cloudflare/Nginx/AWS/bare-metal). Top-of-page migration callout + Cloudflare trust-boundary warning. `docs/contrib/ratelimit.md` updated, `mkdocs.yml` nav extended.

## Migration

The old `--ratelimit-trust-proxy=true` matched Nginx with `ngx_http_realip_module`. For that setup, the equivalent now is:

```
--client-ip-mode=header --client-ip-header=X-Real-IP
```

Other deployments (Cloudflare, AWS ALB, etc.) pick a different combination — the [Client IP guide](https://burrow.andrich.dev/guide/client-ip/) has the decision tree.

## Test plan

- [x] `mise run test` green (incl. 17 new tests across `app/`, `server/`, root, `contrib/ratelimit/`)
- [x] `mise run lint` clean (0 issues)
- [x] `mise run docs-build` clean
- [ ] Manual: boot `example/notes` with `--client-ip-mode=header --client-ip-header=X-Real-IP`, curl with the header set, verify ratelimit keys on the header value (deferred to release-tag smoke)