### PR TITLE
feat(auth): username and email validators for registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 - **Framework-wide client IP via chi v5.3.0's new `ClientIPFromX` API.** Four `--client-ip-mode` choices (`remote-addr`, `header`, `xff-trusted-proxies`, `xff-trusted-cidrs`), each with its companion flag — boot fails fast on missing/mismatched companions. `burrow.ClientIP(ctx)` and `burrow.ClientIPAddr(ctx)` expose the value to contribs without a chi import. ratelimit is the first consumer; future request-logging / geofencing / abuse-detection can read from the same source.
 - **contrib/auth: `<noscript>` fallback in the public auth layout.** Login/register/recovery pages render a translated noscript block so JS-off browsers see an explanation instead of a silently-broken passkey button. New i18n keys `auth-noscript-{title,body,link-text}` ship in English + German.
+- **contrib/auth: `WithUsernameValidator` / `WithEmailValidator` registration hooks.** Reject otherwise-free-but-unwanted usernames or email addresses at signup (reserved handles, blocked addresses) — the validator runs before user creation and its error message is shown to the user. Uniqueness stays enforced by the database. See [Registration Validators](https://burrow.andrich.dev/contrib/auth/#registration-validators).
 
 ### Changed
 

--- a/contrib/auth/app.go
+++ b/contrib/auth/app.go
@@ -88,6 +88,9 @@ type App[P any] struct {
 	withLocale     func(ctx context.Context, lang string) context.Context
 	emailTask      *burrow.TaskDefinition[emailJobPayload]
 	logo           template.HTML
+
+	usernameValidator func(context.Context, string) error
+	emailValidator    func(context.Context, string) error
 }
 
 // Config holds auth-specific configuration.
@@ -140,6 +143,32 @@ func WithEmailService[P any](e EmailService) Option[P] {
 // Leaving the option unset preserves the historic default ([RoleUser]).
 func WithDefaultRole[P any](role string) Option[P] {
 	return func(a *App[P]) { a.defaultRole = role }
+}
+
+// WithUsernameValidator sets a validator invoked during registration in
+// username mode, after the username is read and any invite is checked but
+// before the user is created. Returning a non-nil error aborts
+// registration with HTTP 400 and the error's message is shown to the end
+// user — so return a clean, user-facing message (e.g. "username is
+// reserved"), not a wrapped internal error. Uniqueness is already enforced
+// by the database; use this for policy rejections such as reserved handles.
+// The validator only runs in username mode; for email mode use
+// [WithEmailValidator]. Leaving it unset is a no-op (current behaviour).
+func WithUsernameValidator[P any](fn func(context.Context, string) error) Option[P] {
+	return func(a *App[P]) { a.usernameValidator = fn }
+}
+
+// WithEmailValidator sets a validator invoked during registration in email
+// mode, after the email is read and any invite is checked but before the
+// user is created. Returning a non-nil error aborts registration with HTTP
+// 400 and the error's message is shown to the end user — so return a clean,
+// user-facing message, not a wrapped internal error. Uniqueness is already
+// enforced by the database; use this for policy rejections such as blocked
+// addresses or domain restrictions. The validator only runs in email mode;
+// for username mode use [WithUsernameValidator]. Leaving it unset is a
+// no-op (current behaviour).
+func WithEmailValidator[P any](fn func(context.Context, string) error) Option[P] {
+	return func(a *App[P]) { a.emailValidator = fn }
 }
 
 // validateDefaultRole reports whether the role string is acceptable as

--- a/contrib/auth/app_test.go
+++ b/contrib/auth/app_test.go
@@ -1342,6 +1342,24 @@ func TestWithAuthLayoutOption(t *testing.T) {
 	assert.Equal(t, "test/layout", app.authLayout, "authLayout should be set via WithAuthLayout option")
 }
 
+func TestWithUsernameValidatorOption(t *testing.T) {
+	fn := func(_ context.Context, _ string) error { return nil }
+	app := New[EmptyProfile](WithUsernameValidator[EmptyProfile](fn))
+	require.NotNil(t, app.usernameValidator, "usernameValidator should be set via WithUsernameValidator option")
+}
+
+func TestWithEmailValidatorOption(t *testing.T) {
+	fn := func(_ context.Context, _ string) error { return nil }
+	app := New[EmptyProfile](WithEmailValidator[EmptyProfile](fn))
+	require.NotNil(t, app.emailValidator, "emailValidator should be set via WithEmailValidator option")
+}
+
+func TestNewWithoutValidators(t *testing.T) {
+	app := New[EmptyProfile]()
+	assert.Nil(t, app.usernameValidator, "usernameValidator must be nil by default")
+	assert.Nil(t, app.emailValidator, "emailValidator must be nil by default")
+}
+
 func TestPublicAuthRoutesUseAuthLayout(t *testing.T) {
 	// Set up a mock renderer that captures the layout from context.
 	var capturedLayout string

--- a/contrib/auth/example_test.go
+++ b/contrib/auth/example_test.go
@@ -49,3 +49,42 @@ func ExampleIsAuthenticated() {
 	// false
 	// true
 }
+
+func ExampleWithUsernameValidator() {
+	// Reject usernames that collide with reserved handles. The returned
+	// error's message is shown to the user, so keep it clean and specific.
+	reserved := map[string]bool{"posts": true, "notes": true, "all": true}
+	validate := func(_ context.Context, username string) error {
+		if reserved[username] {
+			return fmt.Errorf("username %q is reserved", username)
+		}
+		return nil
+	}
+
+	_ = auth.New[auth.EmptyProfile](auth.WithUsernameValidator[auth.EmptyProfile](validate))
+
+	fmt.Println(validate(context.Background(), "posts"))
+	fmt.Println(validate(context.Background(), "alice"))
+	// Output:
+	// username "posts" is reserved
+	// <nil>
+}
+
+func ExampleWithEmailValidator() {
+	// Block abusive or unwanted addresses in email mode. Uniqueness is
+	// already enforced by the database — use this for policy rejections.
+	validate := func(_ context.Context, email string) error {
+		if email == "blocked@example.com" {
+			return fmt.Errorf("email address is not allowed")
+		}
+		return nil
+	}
+
+	_ = auth.New[auth.EmptyProfile](auth.WithEmailValidator[auth.EmptyProfile](validate))
+
+	fmt.Println(validate(context.Background(), "blocked@example.com"))
+	fmt.Println(validate(context.Background(), "alice@example.com"))
+	// Output:
+	// email address is not allowed
+	// <nil>
+}

--- a/contrib/auth/handlers_registration.go
+++ b/contrib/auth/handlers_registration.go
@@ -94,10 +94,20 @@ func (a *App[P]) RegisterBegin(w http.ResponseWriter, r *http.Request) error {
 		if req.Email == "" {
 			return errorJSON(w, http.StatusBadRequest, "email is required")
 		}
+		if a.emailValidator != nil {
+			if err := a.emailValidator(ctx, req.Email); err != nil {
+				return errorJSON(w, http.StatusBadRequest, err.Error())
+			}
+		}
 		user, createErr = a.repo.CreateUserWithEmail(ctx, req.Email)
 	} else {
 		if req.Username == "" {
 			return errorJSON(w, http.StatusBadRequest, "username is required")
+		}
+		if a.usernameValidator != nil {
+			if err := a.usernameValidator(ctx, req.Username); err != nil {
+				return errorJSON(w, http.StatusBadRequest, err.Error())
+			}
 		}
 		user, createErr = a.repo.CreateUser(ctx, req.Username)
 	}

--- a/contrib/auth/handlers_test.go
+++ b/contrib/auth/handlers_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -440,6 +441,95 @@ func TestRegisterBeginUsernameExists(t *testing.T) {
 	assert.NotContains(t, rec.Body.String(), "publicKey", "must not start WebAuthn flow for existing user")
 }
 
+// postRegisterBegin issues a register/begin request with the given JSON
+// body and returns the recorder. Shared by the validator table tests.
+func postRegisterBegin(t *testing.T, h *App[EmptyProfile], jsonBody string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", strings.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithSession(req, nil)
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.RegisterBegin(rec, req))
+	return rec
+}
+
+// TestRegisterBeginValidator covers the username- and email-mode
+// registration validators: a non-nil error rejects with 400 and the
+// message reaches the user without creating a user, and a passing
+// validator is invoked and lets registration proceed.
+func TestRegisterBeginValidator(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile], *mockRenderer)
+		install func(h *App[EmptyProfile], fn func(context.Context, string) error)
+		body    string
+		stored  string
+	}{
+		{
+			name:    "username mode",
+			setup:   setupTestApp,
+			install: func(h *App[EmptyProfile], fn func(context.Context, string) error) { h.usernameValidator = fn },
+			body:    `{"username":"candidate"}`,
+			stored:  "candidate",
+		},
+		{
+			name:    "email mode",
+			setup:   setupTestAppEmailMode,
+			install: func(h *App[EmptyProfile], fn func(context.Context, string) error) { h.emailValidator = fn },
+			body:    `{"email":"candidate@example.com"}`,
+			stored:  "candidate@example.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" rejects", func(t *testing.T) {
+			h, repo, _ := tc.setup(t)
+			tc.install(h, func(context.Context, string) error { return errors.New("value is not allowed") })
+
+			rec := postRegisterBegin(t, h, tc.body)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "value is not allowed", "validator error message must reach the user")
+			assert.NotContains(t, rec.Body.String(), "publicKey", "must not start WebAuthn flow for rejected value")
+
+			users, err := repo.ListUsers(context.Background())
+			require.NoError(t, err)
+			assert.Empty(t, users, "rejected value must not create a user")
+		})
+
+		t.Run(tc.name+" passes", func(t *testing.T) {
+			h, repo, _ := tc.setup(t)
+			called := false
+			tc.install(h, func(context.Context, string) error { called = true; return nil })
+
+			rec := postRegisterBegin(t, h, tc.body)
+
+			assert.True(t, called, "validator must be invoked")
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), "publicKey")
+
+			users, err := repo.ListUsers(context.Background())
+			require.NoError(t, err)
+			require.Len(t, users, 1)
+			assert.Equal(t, tc.stored, users[0].Username)
+		})
+	}
+}
+
+func TestRegisterBeginNilUsernameValidatorUnchanged(t *testing.T) {
+	h, repo, _ := setupTestApp(t)
+	require.Nil(t, h.usernameValidator, "default app must have no username validator")
+
+	rec := postRegisterBegin(t, h, `{"username":"newuser"}`)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "publicKey")
+
+	users, err := repo.ListUsers(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, users, 1)
+}
+
 func TestRegisterBeginInvalidJSON(t *testing.T) {
 	h, _, _ := setupTestApp(t)
 	body := strings.NewReader(`{invalid}`)
@@ -452,6 +542,18 @@ func TestRegisterBeginInvalidJSON(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRegisterBeginUsernameValidatorIgnoredInEmailMode(t *testing.T) {
+	h, _, _ := setupTestAppEmailMode(t)
+	h.usernameValidator = func(_ context.Context, _ string) error {
+		return errors.New("must not run in email mode")
+	}
+
+	rec := postRegisterBegin(t, h, `{"email":"someone@example.com"}`)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "username validator must not gate email-mode registration")
+	assert.Contains(t, rec.Body.String(), "publicKey")
 }
 
 func TestRegisterBeginEmailMode(t *testing.T) {

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -41,6 +41,29 @@ Other constructor options:
 - `auth.WithEmailService(svc)` — wire up an email backend (see [Email Service](#email-service)).
 - `auth.WithLogoComponent(html)` — render a small logo above login/register/recovery pages.
 - `auth.WithDefaultRole(role)` — assign every newly-registered user a role other than `RoleUser` (see [Default Role for New Users](#default-role-for-new-users)).
+- `auth.WithUsernameValidator(fn)` / `auth.WithEmailValidator(fn)` — reject chosen usernames or email addresses at registration time (see [Registration Validators](#registration-validators)).
+
+## Registration Validators
+
+Uniqueness of usernames and emails is already enforced by the database. The validators are for *policy* rejections — reserved handles, blocked addresses, domain restrictions — values that are free but unwanted.
+
+```go
+reserved := map[string]bool{"posts": true, "notes": true, "all": true}
+
+srv.Register(auth.New[auth.EmptyProfile](
+    auth.WithUsernameValidator[auth.EmptyProfile](func(ctx context.Context, username string) error {
+        if reserved[username] {
+            return fmt.Errorf("username %q is reserved", username)
+        }
+        return nil
+    }),
+))
+```
+
+The matching validator runs during registration after the value is read and any invite is checked, but before the user is created. `WithUsernameValidator` runs only in username mode; `WithEmailValidator` only in email mode — the modes are mutually exclusive, so exactly one fires. A non-nil error aborts registration with HTTP 400.
+
+!!! warning "The error message is shown to the user"
+    The validator's error message is returned verbatim in the registration response and surfaced by the WebAuthn client. Return a clean, user-facing message (e.g. `"username is reserved"`), not a wrapped internal error.
 
 ## Default Templates
 


### PR DESCRIPTION
## Summary

Adds two registration extension points to `contrib/auth`:

- `WithUsernameValidator[P](func(context.Context, string) error)` — runs in username mode
- `WithEmailValidator[P](func(context.Context, string) error)` — runs in email mode

The matching validator fires during `RegisterBegin` after the value is read and any invite is checked, but **before** the user is created. A non-nil error aborts registration with HTTP 400 and the error message is shown to the user. The modes are mutually exclusive (`--auth-use-email`), so exactly one validator fires.

Uniqueness stays enforced by the database (`den:"unique"` on username/email); these hooks are for **policy** rejections — reserved handles, blocked/abusive addresses, domain restrictions. Leaving a validator unset is a no-op (current behavior).

## Motivation

Downstream apps need to reject otherwise-valid values at signup: reserved ActivityPub actor handles in username mode, and abusive email addresses in email mode (a harmless username paired with an offensive address).

## Test plan

- Table-driven `TestRegisterBeginValidator` (both modes × reject/pass): rejection returns 400 with the message and creates no user; a passing validator is invoked and registration proceeds.
- `TestRegisterBeginUsernameValidatorIgnoredInEmailMode` pins cross-mode isolation.
- Nil-validator regression test confirms unchanged default behavior.
- Option tests + runnable godoc examples for both options.
- `go build ./...`, full `go test ./...` (1762 passed), `golangci-lint run` (0 issues), `docs-build` (no warnings).