### PR TITLE
feat(auth): API-key bearer authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- **contrib/auth: API-key (personal access token) bearer auth.** `App.RequireAPIKey()` middleware authenticates non-browser clients via `Authorization: Bearer <token>`, loading the key's owner into the request context exactly like the session path — so `CurrentUser` and `RequireStaff`/`RequireAdmin` compose on top unchanged. Tokens are `brw_`-prefixed, stored only as their SHA256 hash (plaintext shown once), and managed through the auth repository (`CreateAPIKey`/`ListAPIKeysByUser`/`DeleteAPIKey`). Bearer API routes must be declared CSRF-exempt via `csrf.ExemptPaths`.
+
 ## 0.26.0 — 2026-05-31
 
 ### Breaking Changes

--- a/contrib/auth/apikey.go
+++ b/contrib/auth/apikey.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/oliverandrich/burrow"
+)
+
+// RequireAPIKey returns middleware that authenticates a request via an API
+// key presented as an `Authorization: Bearer <token>` header. It is the
+// non-browser counterpart to session auth: a valid key loads its owning
+// user into the request context — both [WithUser] and a [burrow.AuthChecker],
+// exactly as the session middleware does — so [CurrentUser], the core
+// navLinks function, and [RequireStaff]/[RequireAdmin] all behave
+// identically regardless of how the request authenticated.
+//
+// Unlike the session middleware (which lets unauthenticated requests pass
+// through to be redirected to login), this is a hard gate: a missing,
+// malformed, unknown, expired, or inactive-user key is rejected with 401.
+// The error uses [burrow.RenderError], so API clients sending
+// `Accept: application/json` receive a JSON body.
+//
+// The key inherits its user's role; per-role gating is achieved by chaining
+// the existing role middleware after it, e.g.
+//
+//	r.Use(authApp.RequireAPIKey())
+//	r.Use(auth.RequireStaff())
+func (a *App[P]) RequireAPIKey() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := bearerToken(r)
+			if token == "" {
+				unauthorized(w, r)
+				return
+			}
+
+			key, err := a.repo.GetAPIKeyByHash(r.Context(), HashToken(token))
+			if err != nil || key.IsExpired() {
+				unauthorized(w, r)
+				return
+			}
+
+			user, err := a.repo.GetUserByID(r.Context(), key.UserID)
+			if err != nil || !user.IsActive {
+				unauthorized(w, r)
+				return
+			}
+
+			next.ServeHTTP(w, r.WithContext(setAuthContext(r.Context(), user)))
+		})
+	}
+}
+
+// bearerToken extracts the token from an `Authorization: Bearer <token>`
+// header, or returns "" when the header is absent or not a bearer scheme.
+func bearerToken(r *http.Request) string {
+	scheme, token, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(token)
+}
+
+// unauthorized rejects a request with 401 and a Bearer challenge.
+func unauthorized(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	burrow.RenderError(w, r, http.StatusUnauthorized, "unauthorized")
+}

--- a/contrib/auth/apikey_test.go
+++ b/contrib/auth/apikey_test.go
@@ -1,0 +1,226 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAPIKey(t *testing.T) {
+	plaintext, hash, err := GenerateAPIKey()
+	require.NoError(t, err)
+
+	assert.Greater(t, len(plaintext), len(APIKeyPrefix), "plaintext should carry the prefix and random body")
+	assert.Equal(t, APIKeyPrefix, plaintext[:len(APIKeyPrefix)])
+	assert.Equal(t, HashToken(plaintext), hash, "stored hash must be the SHA256 of the plaintext")
+
+	other, _, err := GenerateAPIKey()
+	require.NoError(t, err)
+	assert.NotEqual(t, plaintext, other, "generated tokens must be unique")
+}
+
+func TestAPIKeyIsExpired(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	assert.False(t, (&APIKey{}).IsExpired(), "key without expiry never expires")
+	assert.False(t, (&APIKey{ExpiresAt: &future}).IsExpired())
+	assert.True(t, (&APIKey{ExpiresAt: &past}).IsExpired())
+}
+
+// --- Repository tests ---
+
+func TestCreateAndGetAPIKey(t *testing.T) {
+	db := openTestDB(t)
+	repo := NewRepository[EmptyProfile](db)
+	ctx := context.Background()
+
+	user, err := repo.CreateUser(ctx, "alice")
+	require.NoError(t, err)
+
+	plaintext, key, err := repo.CreateAPIKey(ctx, user.ID, "ci-token", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, plaintext)
+	assert.Equal(t, user.ID, key.UserID)
+	assert.Equal(t, "ci-token", key.Label)
+	assert.NotEqual(t, plaintext, key.Hash, "the record stores the hash, not the plaintext")
+
+	got, err := repo.GetAPIKeyByHash(ctx, HashToken(plaintext))
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, got.ID)
+}
+
+func TestGetAPIKeyByHashNotFound(t *testing.T) {
+	db := openTestDB(t)
+	repo := NewRepository[EmptyProfile](db)
+
+	_, err := repo.GetAPIKeyByHash(context.Background(), HashToken("brw_nope"))
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestListAPIKeysByUser(t *testing.T) {
+	db := openTestDB(t)
+	repo := NewRepository[EmptyProfile](db)
+	ctx := context.Background()
+
+	alice, err := repo.CreateUser(ctx, "alice")
+	require.NoError(t, err)
+	bob, err := repo.CreateUser(ctx, "bob")
+	require.NoError(t, err)
+
+	_, _, err = repo.CreateAPIKey(ctx, alice.ID, "one", nil)
+	require.NoError(t, err)
+	_, _, err = repo.CreateAPIKey(ctx, alice.ID, "two", nil)
+	require.NoError(t, err)
+	_, _, err = repo.CreateAPIKey(ctx, bob.ID, "bob-key", nil)
+	require.NoError(t, err)
+
+	keys, err := repo.ListAPIKeysByUser(ctx, alice.ID)
+	require.NoError(t, err)
+	assert.Len(t, keys, 2, "only the owner's keys are listed")
+}
+
+func TestDeleteAPIKeyScopedToUser(t *testing.T) {
+	db := openTestDB(t)
+	repo := NewRepository[EmptyProfile](db)
+	ctx := context.Background()
+
+	alice, err := repo.CreateUser(ctx, "alice")
+	require.NoError(t, err)
+	bob, err := repo.CreateUser(ctx, "bob")
+	require.NoError(t, err)
+
+	_, key, err := repo.CreateAPIKey(ctx, alice.ID, "alice-key", nil)
+	require.NoError(t, err)
+
+	// Bob cannot delete Alice's key by guessing its ID.
+	require.NoError(t, repo.DeleteAPIKey(ctx, key.ID, bob.ID))
+	keys, err := repo.ListAPIKeysByUser(ctx, alice.ID)
+	require.NoError(t, err)
+	assert.Len(t, keys, 1, "wrong-owner delete is a no-op")
+
+	// The owner can delete it.
+	require.NoError(t, repo.DeleteAPIKey(ctx, key.ID, alice.ID))
+	keys, err = repo.ListAPIKeysByUser(ctx, alice.ID)
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+}
+
+// --- Middleware tests ---
+
+// apiKeyRouter wires RequireAPIKey in front of a handler that echoes the
+// authenticated username, so tests can assert who (if anyone) got through.
+func apiKeyRouter(app *App[EmptyProfile], extra ...func(http.Handler) http.Handler) chi.Router {
+	r := chi.NewRouter()
+	r.Use(app.RequireAPIKey())
+	for _, m := range extra {
+		r.Use(m)
+	}
+	r.Get("/api/ping", func(w http.ResponseWriter, r *http.Request) {
+		user := CurrentUser[EmptyProfile](r.Context())
+		_, _ = w.Write([]byte(user.Username))
+	})
+	return r
+}
+
+func apiKeyRequest(ctx context.Context, token string) *http.Request {
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/ping", nil)
+	req.Header.Set("Accept", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req
+}
+
+func TestRequireAPIKeyAllowsValidKey(t *testing.T) {
+	app, repo := newTestApp(t)
+
+	user, err := repo.CreateUser(context.Background(), "alice")
+	require.NoError(t, err)
+	plaintext, _, err := repo.CreateAPIKey(context.Background(), user.ID, "key", nil)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	apiKeyRouter(app).ServeHTTP(rec, apiKeyRequest(t.Context(), plaintext))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "alice", rec.Body.String(), "the key's owner is the authenticated user")
+}
+
+func TestRequireAPIKeyRejectsMissingHeader(t *testing.T) {
+	app, _ := newTestApp(t)
+
+	rec := httptest.NewRecorder()
+	apiKeyRouter(app).ServeHTTP(rec, apiKeyRequest(t.Context(), ""))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, "Bearer", rec.Header().Get("WWW-Authenticate"))
+	assert.Contains(t, rec.Body.String(), "error")
+}
+
+func TestRequireAPIKeyRejectsUnknownToken(t *testing.T) {
+	app, _ := newTestApp(t)
+
+	rec := httptest.NewRecorder()
+	apiKeyRouter(app).ServeHTTP(rec, apiKeyRequest(t.Context(), "brw_unknown"))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireAPIKeyRejectsExpiredKey(t *testing.T) {
+	app, repo := newTestApp(t)
+
+	user, err := repo.CreateUser(context.Background(), "alice")
+	require.NoError(t, err)
+	past := time.Now().Add(-time.Hour)
+	plaintext, _, err := repo.CreateAPIKey(context.Background(), user.ID, "expired", &past)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	apiKeyRouter(app).ServeHTTP(rec, apiKeyRequest(t.Context(), plaintext))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireAPIKeyRejectsInactiveUser(t *testing.T) {
+	app, repo := newTestApp(t)
+	ctx := context.Background()
+
+	user, err := repo.CreateUser(ctx, "alice")
+	require.NoError(t, err)
+	plaintext, _, err := repo.CreateAPIKey(ctx, user.ID, "key", nil)
+	require.NoError(t, err)
+	require.NoError(t, repo.SetUserActive(ctx, user.ID, false))
+
+	rec := httptest.NewRecorder()
+	apiKeyRouter(app).ServeHTTP(rec, apiKeyRequest(t.Context(), plaintext))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRequireAPIKeyComposesWithRequireStaff(t *testing.T) {
+	app, repo := newTestApp(t)
+	ctx := context.Background()
+
+	// Non-staff user is authenticated by the key but blocked by RequireStaff.
+	user, err := repo.CreateUser(ctx, "alice")
+	require.NoError(t, err)
+	plaintext, _, err := repo.CreateAPIKey(ctx, user.ID, "key", nil)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	apiKeyRouter(app, RequireStaff()).ServeHTTP(rec, apiKeyRequest(t.Context(), plaintext))
+	assert.Equal(t, http.StatusForbidden, rec.Code, "valid key, insufficient role → 403")
+
+	// Promote to staff and retry.
+	require.NoError(t, repo.SetUserRole(ctx, user.ID, RoleStaff))
+	rec = httptest.NewRecorder()
+	apiKeyRouter(app, RequireStaff()).ServeHTTP(rec, apiKeyRequest(t.Context(), plaintext))
+	assert.Equal(t, http.StatusOK, rec.Code, "staff key passes the role gate")
+}

--- a/contrib/auth/app.go
+++ b/contrib/auth/app.go
@@ -276,7 +276,7 @@ func (a *App[P]) StaticFS() (string, fs.FS) {
 
 // Documents returns the Den document types registered by this app.
 func (a *App[P]) Documents() []document.Document {
-	return []document.Document{&User[P]{}, &Credential{}, &RecoveryCode{}, &EmailVerificationToken{}, &Invite{}}
+	return []document.Document{&User[P]{}, &Credential{}, &RecoveryCode{}, &EmailVerificationToken{}, &Invite{}, &APIKey{}}
 }
 
 // TranslationFS returns the embedded translation files for auto-discovery by the i18n app.
@@ -420,13 +420,7 @@ func (a *App[P]) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := WithUser(r.Context(), user)
-		ctx = burrow.WithAuthChecker(ctx, burrow.AuthChecker{
-			IsAuthenticated: func() bool { return true },
-			IsStaff:         func() bool { return user.IsStaff() },
-			IsAdmin:         func() bool { return user.IsAdmin() },
-		})
-		next.ServeHTTP(w, r.WithContext(ctx))
+		next.ServeHTTP(w, r.WithContext(setAuthContext(r.Context(), user)))
 	})
 }
 

--- a/contrib/auth/context.go
+++ b/contrib/auth/context.go
@@ -8,6 +8,8 @@ package auth
 import (
 	"context"
 	"html/template"
+
+	"github.com/oliverandrich/burrow"
 )
 
 // ctxKeyUser is the context key for the authenticated user. The value
@@ -49,6 +51,20 @@ func IsAuthenticated(ctx context.Context) bool {
 // know the Profile type — only the [CurrentUser] read site does.
 func WithUser(ctx context.Context, user any) context.Context {
 	return context.WithValue(ctx, ctxKeyUser{}, user)
+}
+
+// setAuthContext stamps an authenticated user into the request context: both
+// the user value (via [WithUser]) and a [burrow.AuthChecker] for the core
+// navLinks / role-gating template helpers. Both the session middleware and
+// the API-key middleware funnel through here, so the authenticated-context
+// contract has a single source.
+func setAuthContext[P any](ctx context.Context, user *User[P]) context.Context {
+	ctx = WithUser(ctx, user)
+	return burrow.WithAuthChecker(ctx, burrow.AuthChecker{
+		IsAuthenticated: func() bool { return true },
+		IsStaff:         func() bool { return user.IsStaff() },
+		IsAdmin:         func() bool { return user.IsAdmin() },
+	})
 }
 
 // ctxKeyLogo is the context key for the optional auth page logo component.

--- a/contrib/auth/models.go
+++ b/contrib/auth/models.go
@@ -149,6 +149,27 @@ func TransportsFromWebAuthn(transports []protocol.AuthenticatorTransport) string
 	return strings.Join(strs, ",")
 }
 
+// APIKey is a hashed API key (personal access token) used for bearer
+// authentication of non-browser API clients. Only the SHA256 hash of the
+// token is stored; the plaintext is shown to the user exactly once at
+// creation. A key inherits the role of its owning user — the
+// [App.RequireAPIKey] middleware loads that user into the request context
+// just like the session path, so [RequireStaff]/[RequireAdmin] compose on
+// top unchanged.
+type APIKey struct {
+	document.Base
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Hash      string     `json:"hash" den:"unique"`
+	UserID    string     `json:"user_id" den:"index"`
+	Label     string     `json:"label"`
+}
+
+// IsExpired reports whether the key carries an expiry that is in the past.
+// Keys without an expiry never expire.
+func (k *APIKey) IsExpired() bool {
+	return k.ExpiresAt != nil && time.Now().After(*k.ExpiresAt)
+}
+
 // RecoveryCode stores a hashed recovery code for account recovery.
 type RecoveryCode struct {
 	document.Base

--- a/contrib/auth/repository.go
+++ b/contrib/auth/repository.go
@@ -401,6 +401,73 @@ func (r *Repository[P]) CountUserCredentials(ctx context.Context, userID string)
 	return count, nil
 }
 
+// --- API key methods ---
+
+// CreateAPIKey generates a new API key for a user, persists only its SHA256
+// hash, and returns the plaintext token. The plaintext is the only time the
+// token is recoverable — callers must surface it to the user immediately and
+// never store it. A nil expiresAt creates a key that never expires.
+func (r *Repository[P]) CreateAPIKey(ctx context.Context, userID, label string, expiresAt *time.Time) (string, *APIKey, error) {
+	plaintext, hash, err := GenerateAPIKey()
+	if err != nil {
+		return "", nil, fmt.Errorf("create api key for user %s: %w", userID, err)
+	}
+	key := &APIKey{UserID: userID, Label: label, Hash: hash, ExpiresAt: expiresAt}
+	if err := den.Save(ctx, r.db, key); err != nil {
+		return "", nil, fmt.Errorf("create api key for user %s: %w", userID, err)
+	}
+	return plaintext, key, nil
+}
+
+// GetAPIKeyByHash retrieves an API key by its SHA256 hash. Callers pass
+// HashToken(plaintext); the lookup is an exact match on the unique, indexed
+// hash column.
+func (r *Repository[P]) GetAPIKeyByHash(ctx context.Context, hash string) (*APIKey, error) {
+	key, err := den.NewQuery[APIKey](r.db, where.Field("hash").Eq(hash)).First(ctx)
+	if err != nil {
+		if errors.Is(err, den.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get api key by hash: %w", err)
+	}
+	return key, nil
+}
+
+// ListAPIKeysByUser returns a user's API keys ordered by creation time
+// descending. Hashes are included; plaintext tokens are never recoverable.
+func (r *Repository[P]) ListAPIKeysByUser(ctx context.Context, userID string) ([]APIKey, error) {
+	keys, err := den.NewQuery[APIKey](r.db, where.Field("user_id").Eq(userID)).
+		Sort("_created_at", den.Desc).All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list api keys for user %s: %w", userID, err)
+	}
+	result := make([]APIKey, len(keys))
+	for i, k := range keys {
+		result[i] = *k
+	}
+	return result, nil
+}
+
+// DeleteAPIKey revokes an API key. The delete is scoped to the owning user
+// so one user cannot revoke another's key by guessing its ID. Deleting a
+// non-existent (or already-deleted) key is a no-op.
+func (r *Repository[P]) DeleteAPIKey(ctx context.Context, keyID, userID string) error {
+	key, err := den.NewQuery[APIKey](r.db,
+		where.Field("_id").Eq(keyID),
+		where.Field("user_id").Eq(userID),
+	).First(ctx)
+	if err != nil {
+		if errors.Is(err, den.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("delete api key %s for user %s: %w", keyID, userID, err)
+	}
+	if err := den.Delete(ctx, r.db, key); err != nil {
+		return fmt.Errorf("delete api key %s for user %s: %w", keyID, userID, err)
+	}
+	return nil
+}
+
 // --- Recovery code methods ---
 
 // CreateRecoveryCodes creates recovery codes for a user.

--- a/contrib/auth/services.go
+++ b/contrib/auth/services.go
@@ -49,25 +49,42 @@ func HashToken(token string) string {
 	return hex.EncodeToString(hash[:])
 }
 
+// generateToken generates TokenLength random bytes as a hex string with an
+// optional prefix, plus its SHA256 hash for storage. The plaintext is the
+// only recoverable form; only the hash is ever persisted.
+func generateToken(prefix string) (plaintext, hash string, err error) {
+	b := make([]byte, TokenLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	plaintext = prefix + hex.EncodeToString(b)
+	return plaintext, HashToken(plaintext), nil
+}
+
 // GenerateToken generates a new verification token.
 // Returns (plaintext token, SHA256 hash for storage, expiry time, error).
 func GenerateToken() (string, string, time.Time, error) {
-	b := make([]byte, TokenLength)
-	if _, err := rand.Read(b); err != nil {
-		return "", "", time.Time{}, fmt.Errorf("generate random bytes: %w", err)
+	plaintext, hash, err := generateToken("")
+	if err != nil {
+		return "", "", time.Time{}, err
 	}
-	plaintext := hex.EncodeToString(b)
-	return plaintext, HashToken(plaintext), time.Now().Add(TokenExpiry), nil
+	return plaintext, hash, time.Now().Add(TokenExpiry), nil
 }
 
 // GenerateInviteToken generates a random invite token and its SHA256 hash.
 func GenerateInviteToken() (plaintext, hash string, err error) {
-	b := make([]byte, TokenLength)
-	if _, err := rand.Read(b); err != nil {
-		return "", "", err
-	}
-	plaintext = hex.EncodeToString(b)
-	return plaintext, HashToken(plaintext), nil
+	return generateToken("")
+}
+
+// APIKeyPrefix is prepended to generated API-key plaintext tokens. The
+// fixed prefix makes leaked keys recognisable to secret scanners.
+const APIKeyPrefix = "brw_"
+
+// GenerateAPIKey generates a random API-key token and its SHA256 hash. The
+// plaintext is prefixed with [APIKeyPrefix] and must be shown to the user
+// exactly once — only the returned hash is ever persisted.
+func GenerateAPIKey() (plaintext, hash string, err error) {
+	return generateToken(APIKeyPrefix)
 }
 
 // --- Recovery service ---

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -150,6 +150,10 @@ Bcrypt-hashed one-time recovery codes for account access when passkeys are unava
 
 Time-limited invite tokens for invite-only registration.
 
+### APIKey
+
+SHA256-hashed API key (personal access token) for bearer authentication of non-browser clients. Only the hash is stored — the plaintext is shown once at creation. A key inherits the role of its owning user. See [RequireAPIKey](#requireapikey).
+
 ## Routes
 
 All routes are registered under `/auth`:
@@ -260,6 +264,48 @@ func (a *App) AdminRoutes(r chi.Router) {
         r.Get("/settings", a.settings)
     })
 }
+```
+
+### RequireAPIKey
+
+Authenticates non-browser API clients via an API key (personal access token) presented as `Authorization: Bearer <token>`. Unlike the browser middleware, it is a hard gate: a missing, malformed, unknown, expired, or inactive-user key is rejected with **401** (a JSON body when the client sends `Accept: application/json`). A valid key loads its owning user into the request context exactly like the session path, so `CurrentUser`, `RequireStaff`, and `RequireAdmin` all behave identically.
+
+Because it needs database access, `RequireAPIKey` is a method on the app instance (not a package function like `RequireAuth`):
+
+```go
+authApp := auth.New[myapp.Profile]()
+srv := burrow.NewServer(session.New(), csrf.New(), authApp /* , ... */)
+
+// On the app that owns the API routes:
+r.Route("/api", func(r chi.Router) {
+    r.Use(authApp.RequireAPIKey())
+    r.Use(auth.RequireStaff()) // optional: gate by role, composes on top
+    r.Get("/posts", listPosts)
+})
+```
+
+Keys inherit their owner's role, so role gating is done by chaining the existing role middleware after `RequireAPIKey`.
+
+!!! warning "Exempt API routes from CSRF"
+    The bearer path carries no cookie, so it needs no CSRF token — but the global `csrf` middleware still rejects unsafe methods (POST/PUT/DELETE) that arrive without one. Declare your API prefix CSRF-exempt via the [`csrf.ExemptPaths`](csrf.md) capability interface on the app that owns the routes:
+
+    ```go
+    func (a *App) CSRFExemptPaths() []string { return []string{"/api/"} } // prefix match
+    ```
+
+#### Managing keys
+
+There is no built-in UI yet — keys are created, listed, and revoked through the auth repository (`authApp.Repo()`). The plaintext token is returned **once** at creation; show it to the user immediately and never persist it (only the hash is stored):
+
+```go
+repo := authApp.Repo()
+
+// nil expiry = never expires; pass a *time.Time to set one.
+plaintext, key, err := repo.CreateAPIKey(ctx, userID, "ci-deploy", nil)
+// → show `plaintext` (e.g. "brw_…") to the user now; it is unrecoverable afterwards.
+
+keys, _ := repo.ListAPIKeysByUser(ctx, userID) // hashes only, plaintext gone
+_ = repo.DeleteAPIKey(ctx, key.ID, userID)     // revoke (scoped to the owner)
 ```
 
 ## Context Helpers


### PR DESCRIPTION
## Summary

Adds API-key (personal access token) bearer authentication to `contrib/auth`, so non-browser clients can authenticate against burrow apps — the prerequisite for a future declarative CRUD API layer.

- `(*App[P]).RequireAPIKey()` middleware authenticates `Authorization: Bearer <token>` requests. A valid key loads its owning user into the request context exactly like the session path (same `WithUser` + `AuthChecker`), so `CurrentUser` and `RequireStaff`/`RequireAdmin` compose on top unchanged. Missing/invalid/expired/inactive → 401 (JSON when `Accept: application/json`).
- Keys inherit their owner's role; they are stored only as their SHA256 hash (`brw_`-prefixed plaintext shown once) and managed programmatically via the auth repository (`CreateAPIKey`/`GetAPIKeyByHash`/`ListAPIKeysByUser`/`DeleteAPIKey`, owner-scoped revoke).
- The session and bearer paths now share a single `setAuthContext` helper, so the authenticated-context contract has one source.

Bearer API routes must be declared CSRF-exempt via `csrf.ExemptPaths` — documented in the auth guide.

## Test plan

- `go test ./...` — full suite green, incl. new tests for token generation, expiry, owner-scoped repository ops, and the middleware (401 paths + composition with `RequireStaff` → 403/200).
- `golangci-lint run ./...` — clean.
- `mise run docs-build` — no issues.

No HTTP routes or UI ship in this change; key management is programmatic for now. A self-service management page is planned as a follow-up.