### PR TITLE
feat(crud): declarative JSON CRUD resources over Den

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ### Added
 
+- **`crud` package: declarative JSON CRUD APIs.** `crud.NewResource[T](db, opts…)` turns a Den document type into the five standard endpoints (list/get/create/update/delete) as a plain `http.Handler` — mount it with `r.Mount`, or register it into a route group with `Routes(r)` to add custom sibling actions. Options cover ownership scoping (`WithScope`, applied to every action), typed write models (`WithCreate`/`WithUpdate`, mass-assignment-safe), output shaping (`WithPresenter`), sorting, and action subsetting (`Only`/`Except`). Auth and CSRF stay the host's ordinary middleware. See the [JSON CRUD APIs guide](https://burrow.andrich.dev/guide/crud-api/).
 - **contrib/auth: API-key (personal access token) bearer auth.** The automatic user-loading middleware now also resolves an `Authorization: Bearer <token>` header, so non-browser API clients authenticate through the existing gates (`RequireAuth`/`RequireStaff`/`RequireAdmin`) with no extra middleware — a bearer request populates the same context as a session cookie. Those gates now answer API clients (`Accept: application/json`) with a 401 instead of a login redirect. Tokens are `brw_`-prefixed, stored only as their SHA256 hash (plaintext shown once), and managed through the auth repository (`CreateAPIKey`/`ListAPIKeysByUser`/`DeleteAPIKey`). Bearer API routes must be declared CSRF-exempt via `csrf.ExemptPaths`.
 
 ## 0.26.0 — 2026-05-31

--- a/crud/crud_test.go
+++ b/crud/crud_test.go
@@ -1,0 +1,295 @@
+package crud_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/burrowtest"
+	"github.com/oliverandrich/burrow/crud"
+	"github.com/oliverandrich/den"
+	"github.com/oliverandrich/den/document"
+	"github.com/oliverandrich/den/where"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// widget is the test document type.
+type widget struct {
+	document.Base
+	OwnerID string `json:"owner_id" den:"index"`
+	Name    string `json:"name" validate:"required"`
+	Price   int    `json:"price"`
+}
+
+func newDB(t *testing.T) *den.DB {
+	t.Helper()
+	db := burrowtest.DB(t)
+	require.NoError(t, den.Register(t.Context(), db, &widget{}))
+	return db
+}
+
+// save inserts a widget directly (bypassing the API) for arrange steps.
+func save(t *testing.T, db *den.DB, w *widget) *widget {
+	t.Helper()
+	require.NoError(t, den.Save(t.Context(), db, w))
+	return w
+}
+
+// mount returns a router with the resource mounted at /widgets via r.Mount.
+func mount(rs *crud.Resource[widget]) chi.Router {
+	r := chi.NewRouter()
+	r.Mount("/widgets", rs)
+	return r
+}
+
+func do(t *testing.T, h http.Handler, method, target, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req := httptest.NewRequestWithContext(t.Context(), method, target, rdr)
+	req.Header.Set("Accept", "application/json")
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func decode(t *testing.T, rec *httptest.ResponseRecorder, v any) {
+	t.Helper()
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), v))
+}
+
+func TestList(t *testing.T) {
+	db := newDB(t)
+	save(t, db, &widget{Name: "a"})
+	save(t, db, &widget{Name: "b"})
+
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodGet, "/widgets", "", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp burrow.PageResponse[widget]
+	decode(t, rec, &resp)
+	assert.Len(t, resp.Items, 2)
+	assert.Equal(t, 2, resp.Pagination.TotalCount)
+}
+
+func TestListPaginated(t *testing.T) {
+	db := newDB(t)
+	for _, n := range []string{"a", "b", "c"} {
+		save(t, db, &widget{Name: n})
+	}
+
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodGet, "/widgets?limit=2&page=1", "", nil)
+	var resp burrow.PageResponse[widget]
+	decode(t, rec, &resp)
+
+	assert.Len(t, resp.Items, 2, "limit caps the page")
+	assert.Equal(t, 3, resp.Pagination.TotalCount)
+	assert.True(t, resp.Pagination.HasMore)
+}
+
+func TestListScoped(t *testing.T) {
+	db := newDB(t)
+	save(t, db, &widget{OwnerID: "alice", Name: "a"})
+	save(t, db, &widget{OwnerID: "bob", Name: "b"})
+
+	rs := crud.NewResource[widget](db, crud.WithScope[widget](func(r *http.Request) []where.Condition {
+		return []where.Condition{where.Field("owner_id").Eq(r.Header.Get("X-Owner"))}
+	}))
+
+	rec := do(t, mount(rs), http.MethodGet, "/widgets", "", map[string]string{"X-Owner": "alice"})
+	var resp burrow.PageResponse[widget]
+	decode(t, rec, &resp)
+	require.Len(t, resp.Items, 1, "only the scoped owner's rows")
+	assert.Equal(t, "a", resp.Items[0].Name)
+}
+
+func TestGet(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "gadget"})
+
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodGet, "/widgets/"+w.ID, "", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got widget
+	decode(t, rec, &got)
+	assert.Equal(t, "gadget", got.Name)
+}
+
+func TestGetNotFound(t *testing.T) {
+	db := newDB(t)
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodGet, "/widgets/01ABCNONEXISTENT", "", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not_found")
+}
+
+func TestGetScopedHidesOthers(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{OwnerID: "alice", Name: "secret"})
+
+	rs := crud.NewResource[widget](db, crud.WithScope[widget](func(r *http.Request) []where.Condition {
+		return []where.Condition{where.Field("owner_id").Eq(r.Header.Get("X-Owner"))}
+	}))
+
+	// Bob guesses Alice's id — the scope turns it into a 404, not a leak.
+	rec := do(t, mount(rs), http.MethodGet, "/widgets/"+w.ID, "", map[string]string{"X-Owner": "bob"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestCreateBindsOntoT(t *testing.T) {
+	db := newDB(t)
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodPost, "/widgets", `{"name":"new","price":9}`, nil)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var got widget
+	decode(t, rec, &got)
+	assert.Equal(t, "new", got.Name)
+	assert.NotEmpty(t, got.ID, "the stored document is returned with its id")
+}
+
+func TestCreateValidationError(t *testing.T) {
+	db := newDB(t)
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodPost, "/widgets", `{"price":9}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var env struct {
+		Error struct {
+			Code   string            `json:"code"`
+			Fields map[string]string `json:"fields"`
+		} `json:"error"`
+	}
+	decode(t, rec, &env)
+	assert.Equal(t, "validation_failed", env.Error.Code)
+	assert.Contains(t, env.Error.Fields, "name", "the failing field is named")
+}
+
+func TestCreateBadJSON(t *testing.T) {
+	db := newDB(t)
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodPost, "/widgets", `{not json`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid_request")
+}
+
+// createInput is a write DTO that excludes server-owned fields.
+type createInput struct {
+	Name  string `json:"name" validate:"required"`
+	Price int    `json:"price"`
+}
+
+func TestCreateWithDTOBlocksMassAssignment(t *testing.T) {
+	db := newDB(t)
+	rs := crud.NewResource[widget](db, crud.WithCreate(func(in createInput, _ *http.Request) (*widget, error) {
+		return &widget{OwnerID: "system", Name: in.Name, Price: in.Price}, nil
+	}))
+
+	// The client tries to set owner_id; the DTO doesn't carry it, so it's ignored.
+	rec := do(t, mount(rs), http.MethodPost, "/widgets", `{"name":"x","owner_id":"hacker"}`, nil)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var got widget
+	decode(t, rec, &got)
+	assert.Equal(t, "system", got.OwnerID, "server-owned field is not client-settable")
+}
+
+func TestUpdate(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "old", Price: 1})
+
+	for _, method := range []string{http.MethodPut, http.MethodPatch} {
+		rec := do(t, mount(crud.NewResource[widget](db)), method, "/widgets/"+w.ID, `{"name":"updated","price":2}`, nil)
+		assert.Equal(t, http.StatusOK, rec.Code, method)
+
+		got, err := den.FindByID[widget](t.Context(), db, w.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "updated", got.Name, method)
+	}
+}
+
+func TestUpdateWithDTO(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{OwnerID: "alice", Name: "old"})
+
+	rs := crud.NewResource[widget](db, crud.WithUpdate(func(in createInput, dst *widget, _ *http.Request) error {
+		dst.Name = in.Name
+		return nil
+	}))
+
+	rec := do(t, mount(rs), http.MethodPut, "/widgets/"+w.ID, `{"name":"renamed","owner_id":"hacker"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := den.FindByID[widget](t.Context(), db, w.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+	assert.Equal(t, "alice", got.OwnerID, "the DTO can't touch server-owned fields")
+}
+
+func TestDelete(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "doomed"})
+
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodDelete, "/widgets/"+w.ID, "", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, err := den.FindByID[widget](t.Context(), db, w.ID)
+	require.ErrorIs(t, err, den.ErrNotFound)
+}
+
+func TestPresenter(t *testing.T) {
+	db := newDB(t)
+	save(t, db, &widget{Name: "gadget", Price: 5})
+
+	rs := crud.NewResource[widget](db, crud.WithPresenter(func(w *widget) any {
+		return map[string]any{"label": w.Name}
+	}))
+
+	rec := do(t, mount(rs), http.MethodGet, "/widgets", "", nil)
+	var resp struct {
+		Items []map[string]any `json:"items"`
+	}
+	decode(t, rec, &resp)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "gadget", resp.Items[0]["label"])
+	assert.NotContains(t, resp.Items[0], "price", "only presenter fields are exposed")
+}
+
+func TestOnlyDisablesActions(t *testing.T) {
+	db := newDB(t)
+	rs := crud.NewResource[widget](db, crud.Only[widget](crud.ActionList, crud.ActionGet))
+
+	rec := do(t, mount(rs), http.MethodPost, "/widgets", `{"name":"x"}`, nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, "create is not registered")
+}
+
+func TestRoutesWithCustomSibling(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "gadget"})
+
+	r := chi.NewRouter()
+	r.Route("/widgets", func(r chi.Router) {
+		crud.NewResource[widget](db).Routes(r)
+		r.Post("/{id}/publish", burrow.Handle(func(w http.ResponseWriter, r *http.Request) error {
+			return burrow.JSON(w, http.StatusOK, map[string]string{"published": chi.URLParam(r, "id")})
+		}))
+	})
+
+	// Generated action still works.
+	assert.Equal(t, http.StatusOK, do(t, r, http.MethodGet, "/widgets/"+w.ID, "", nil).Code)
+
+	// Custom sibling coexists.
+	rec := do(t, r, http.MethodPost, "/widgets/"+w.ID+"/publish", "", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), w.ID)
+}

--- a/crud/doc.go
+++ b/crud/doc.go
@@ -1,0 +1,26 @@
+// Package crud turns a Den document type into a standard set of JSON CRUD
+// endpoints, so the common 90% of an API can be declared instead of
+// hand-written while custom actions stay ordinary chi routes.
+//
+// A [Resource] is an http.Handler — in the common case, mount it the normal
+// chi way:
+//
+//	r.Route("/api", func(r chi.Router) {
+//	    r.Use(auth.RequireAuth())
+//	    r.Mount("/notes", crud.NewResource[Note](db, crud.WithScope(ownerScope)))
+//	})
+//
+// When a resource needs custom actions alongside the generated ones, register
+// it into a route group with [Resource.Routes] and add the extra routes as
+// ordinary siblings:
+//
+//	r.Route("/api/notes", func(r chi.Router) {
+//	    r.Use(auth.RequireAuth())
+//	    crud.NewResource[Note](db, crud.WithScope(ownerScope)).Routes(r)
+//	    r.Post("/{id}/publish", burrow.Handle(publishNote))
+//	})
+//
+// Authentication, authorization, and CSRF are the host's responsibility via
+// ordinary middleware ([auth.RequireAuth], csrf.ExemptPaths); crud is
+// representation-agnostic and only speaks JSON.
+package crud

--- a/crud/handlers.go
+++ b/crud/handlers.go
@@ -1,0 +1,140 @@
+package crud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/i18n"
+	"github.com/oliverandrich/den"
+)
+
+// errBadRequest marks a malformed request body, distinguishing it from a
+// validation failure (which surfaces as a *burrow.ValidationError).
+var errBadRequest = errors.New("invalid request body")
+
+func (rs *Resource[T]) handleList(w http.ResponseWriter, r *http.Request) error {
+	pr := burrow.ParsePageRequest(r)
+	items, total, err := den.NewQuery[T](rs.db, rs.scopeConds(r)...).
+		Sort(rs.sortField, rs.sortDir).
+		Limit(pr.Limit).
+		Skip(pr.Offset()).
+		AllWithCount(r.Context())
+	if err != nil {
+		return rs.fail(w, r, err)
+	}
+
+	views := make([]any, len(items))
+	for i, doc := range items {
+		views[i] = rs.view(doc)
+	}
+	return burrow.JSON(w, http.StatusOK, burrow.PageResponse[any]{
+		Items:      views,
+		Pagination: burrow.OffsetResult(pr, int(total)),
+	})
+}
+
+func (rs *Resource[T]) handleGet(w http.ResponseWriter, r *http.Request) error {
+	doc, err := rs.find(r)
+	if err != nil {
+		return rs.fail(w, r, err)
+	}
+	return burrow.JSON(w, http.StatusOK, rs.view(doc))
+}
+
+func (rs *Resource[T]) handleCreate(w http.ResponseWriter, r *http.Request) error {
+	doc, err := rs.decodeCreate(r)
+	if err != nil {
+		return rs.fail(w, r, err)
+	}
+	if err := den.Save(r.Context(), rs.db, doc); err != nil {
+		return rs.fail(w, r, err)
+	}
+	return burrow.JSON(w, http.StatusCreated, rs.view(doc))
+}
+
+func (rs *Resource[T]) handleUpdate(w http.ResponseWriter, r *http.Request) error {
+	doc, err := rs.find(r)
+	if err != nil {
+		return rs.fail(w, r, err)
+	}
+	if err := rs.applyUpdate(r, doc); err != nil {
+		return rs.fail(w, r, err)
+	}
+	if err := den.Save(r.Context(), rs.db, doc); err != nil {
+		return rs.fail(w, r, err)
+	}
+	return burrow.JSON(w, http.StatusOK, rs.view(doc))
+}
+
+func (rs *Resource[T]) handleDelete(w http.ResponseWriter, r *http.Request) error {
+	doc, err := rs.find(r)
+	if err != nil {
+		return rs.fail(w, r, err)
+	}
+	if err := den.Delete(r.Context(), rs.db, doc); err != nil {
+		return rs.fail(w, r, err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+// --- decoding helpers ---
+
+// bindValidate decodes the JSON body into v and runs struct validation,
+// marking a decode failure with errBadRequest so [Resource.fail] can tell a
+// malformed body apart from a validation failure or a storage error.
+func bindValidate(r *http.Request, v any) error {
+	if err := burrow.Bind(r, v); err != nil {
+		return fmt.Errorf("%w: %w", errBadRequest, err)
+	}
+	return burrow.Validate(v)
+}
+
+// --- error envelope ---
+
+type errorEnvelope struct {
+	Error errorDetail `json:"error"`
+}
+
+type errorDetail struct {
+	Code   string            `json:"code"`
+	Fields map[string]string `json:"fields,omitempty"`
+}
+
+// fail writes the canonical JSON error envelope for err. Every CRUD error is
+// funnelled through here so API clients always see one envelope shape; the
+// returned error is only the (rare) response-write failure, which
+// burrow.Handle logs.
+func (rs *Resource[T]) fail(w http.ResponseWriter, r *http.Request, err error) error {
+	var ve *burrow.ValidationError
+	switch {
+	case errors.As(err, &ve):
+		return writeError(w, http.StatusBadRequest, "validation_failed", validationFields(r.Context(), ve))
+	case errors.Is(err, den.ErrNotFound):
+		return writeError(w, http.StatusNotFound, "not_found", nil)
+	case errors.Is(err, errBadRequest):
+		return writeError(w, http.StatusBadRequest, "invalid_request", nil)
+	default:
+		slog.Error("crud: request failed", "error", err, "method", r.Method, "path", r.URL.Path) //nolint:gosec // G706: slog escapes values
+		return writeError(w, http.StatusInternalServerError, "internal", nil)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, code string, fields map[string]string) error {
+	return burrow.JSON(w, status, errorEnvelope{Error: errorDetail{Code: code, Fields: fields}})
+}
+
+// validationFields localizes a validation error's messages and flattens them
+// into a field→message map for the envelope.
+func validationFields(ctx context.Context, ve *burrow.ValidationError) map[string]string {
+	ve.Translate(ctx, i18n.TData)
+	fields := make(map[string]string, len(ve.Errors))
+	for _, fe := range ve.Errors {
+		fields[fe.Field] = fe.Message
+	}
+	return fields
+}

--- a/crud/options.go
+++ b/crud/options.go
@@ -1,0 +1,87 @@
+package crud
+
+import (
+	"net/http"
+
+	"github.com/oliverandrich/den"
+	"github.com/oliverandrich/den/where"
+)
+
+// WithScope narrows every action to the conditions returned for the request —
+// typically an ownership or tenancy filter. It applies to list, get, update,
+// and delete alike, so a client cannot reach another's row by guessing its id
+// (the single-row actions 404 instead).
+func WithScope[T any](fn func(*http.Request) []where.Condition) Option[T] {
+	return func(rs *Resource[T]) { rs.scope = fn }
+}
+
+// WithCreate sets a typed write model for create: the request body is bound
+// and validated into C, then fn maps it to a new document. Use it to keep
+// clients from setting server-owned fields (mass assignment). Without it, the
+// body is bound directly onto T.
+func WithCreate[T, C any](fn func(C, *http.Request) (*T, error)) Option[T] {
+	return func(rs *Resource[T]) {
+		rs.decodeCreate = func(r *http.Request) (*T, error) {
+			var dto C
+			if err := bindValidate(r, &dto); err != nil {
+				return nil, err
+			}
+			return fn(dto, r)
+		}
+	}
+}
+
+// WithUpdate sets a typed write model for update: the request body is bound
+// and validated into U, then fn applies it onto the loaded document. Without
+// it, the body is bound directly onto the loaded T.
+func WithUpdate[T, U any](fn func(U, *T, *http.Request) error) Option[T] {
+	return func(rs *Resource[T]) {
+		rs.applyUpdate = func(r *http.Request, dst *T) error {
+			var dto U
+			if err := bindValidate(r, &dto); err != nil {
+				return err
+			}
+			return fn(dto, dst, r)
+		}
+	}
+}
+
+// WithPresenter shapes the JSON written for each document — use it to expose a
+// stable, explicit representation instead of the raw stored fields. Without
+// it, the document is marshalled as-is.
+func WithPresenter[T any](fn func(*T) any) Option[T] {
+	return func(rs *Resource[T]) { rs.present = fn }
+}
+
+// WithSort sets the default ordering for list responses (creation time
+// descending when unset). field is a JSON field name (e.g. "title").
+func WithSort[T any](field string, dir den.SortDirection) Option[T] {
+	return func(rs *Resource[T]) {
+		rs.sortField = field
+		rs.sortDir = dir
+	}
+}
+
+// Only restricts the resource to the named actions ([ActionList], [ActionGet],
+// [ActionCreate], [ActionUpdate], [ActionDelete]). Mutually exclusive with
+// [Except] — the last one applied wins.
+func Only[T any](actions ...string) Option[T] {
+	return func(rs *Resource[T]) { rs.enabled = actionSet(actions) }
+}
+
+// Except disables the named actions, keeping the rest.
+func Except[T any](actions ...string) Option[T] {
+	return func(rs *Resource[T]) {
+		for _, a := range actions {
+			delete(rs.enabled, a)
+		}
+	}
+}
+
+func actionSet(actions []string) map[string]bool {
+	set := make(map[string]bool, len(actions))
+	for _, a := range actions {
+		set[a] = true
+	}
+	return set
+}

--- a/crud/resource.go
+++ b/crud/resource.go
@@ -1,0 +1,135 @@
+package crud
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/den"
+	"github.com/oliverandrich/den/where"
+)
+
+// Action names accepted by [Only] and [Except].
+const (
+	ActionList   = "list"
+	ActionGet    = "get"
+	ActionCreate = "create"
+	ActionUpdate = "update"
+	ActionDelete = "delete"
+)
+
+// Resource exposes a Den document type T as a set of JSON CRUD endpoints.
+// Build it with [NewResource]; mount it with chi's r.Mount or register it into
+// a route group with [Resource.Routes].
+type Resource[T any] struct {
+	db           *den.DB
+	scope        func(*http.Request) []where.Condition
+	decodeCreate func(*http.Request) (*T, error)
+	applyUpdate  func(*http.Request, *T) error
+	present      func(*T) any
+	sortField    string
+	sortDir      den.SortDirection
+	enabled      map[string]bool
+
+	once    sync.Once
+	handler chi.Router
+}
+
+// Option configures a [Resource]. See [WithScope], [WithCreate], [WithUpdate],
+// [WithPresenter], [WithSort], [Only], and [Except].
+type Option[T any] func(*Resource[T])
+
+// NewResource builds a Resource for the Den document type T backed by db.
+// Without options it exposes all five actions, binds request bodies directly
+// onto T (no separate write model), returns the stored document as JSON, and
+// orders lists by creation time descending. Options refine each of those.
+func NewResource[T any](db *den.DB, opts ...Option[T]) *Resource[T] {
+	rs := &Resource[T]{
+		db:        db,
+		sortField: den.FieldCreatedAt,
+		sortDir:   den.Desc,
+		enabled: map[string]bool{
+			ActionList:   true,
+			ActionGet:    true,
+			ActionCreate: true,
+			ActionUpdate: true,
+			ActionDelete: true,
+		},
+	}
+	// Defaults bind the request body directly onto T; WithCreate/WithUpdate
+	// replace these with DTO-backed mappers.
+	rs.decodeCreate = func(r *http.Request) (*T, error) {
+		var v T
+		if err := bindValidate(r, &v); err != nil {
+			return nil, err
+		}
+		return &v, nil
+	}
+	rs.applyUpdate = func(r *http.Request, dst *T) error { return bindValidate(r, dst) }
+	for _, o := range opts {
+		o(rs)
+	}
+	return rs
+}
+
+// Routes registers the resource's enabled actions on r at its current mount
+// path. Use it inside an r.Route group when you want custom sibling routes
+// next to the generated ones.
+func (rs *Resource[T]) Routes(r chi.Router) { rs.register(r) }
+
+// ServeHTTP lets a Resource be mounted directly with chi's r.Mount. The
+// internal router is built on first use, so a resource used only via
+// [Resource.Routes] never allocates one.
+func (rs *Resource[T]) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rs.once.Do(func() {
+		rs.handler = chi.NewRouter()
+		rs.register(rs.handler)
+	})
+	rs.handler.ServeHTTP(w, r)
+}
+
+func (rs *Resource[T]) register(r chi.Router) {
+	if rs.enabled[ActionList] {
+		r.Get("/", burrow.Handle(rs.handleList))
+	}
+	if rs.enabled[ActionCreate] {
+		r.Post("/", burrow.Handle(rs.handleCreate))
+	}
+	if rs.enabled[ActionGet] {
+		r.Get("/{id}", burrow.Handle(rs.handleGet))
+	}
+	if rs.enabled[ActionUpdate] {
+		r.Put("/{id}", burrow.Handle(rs.handleUpdate))
+		r.Patch("/{id}", burrow.Handle(rs.handleUpdate))
+	}
+	if rs.enabled[ActionDelete] {
+		r.Delete("/{id}", burrow.Handle(rs.handleDelete))
+	}
+}
+
+// scopeConds returns the request's ownership/tenancy conditions, or nil.
+func (rs *Resource[T]) scopeConds(r *http.Request) []where.Condition {
+	if rs.scope == nil {
+		return nil
+	}
+	return rs.scope(r)
+}
+
+// view renders a document for output, applying the presenter when set.
+func (rs *Resource[T]) view(doc *T) any {
+	if rs.present != nil {
+		return rs.present(doc)
+	}
+	return doc
+}
+
+// find loads a single document by its path id, narrowed by the scope so one
+// owner cannot reach another's row by guessing an id (it 404s instead).
+func (rs *Resource[T]) find(r *http.Request) (*T, error) {
+	q := den.NewQuery[T](rs.db, where.Field(den.FieldID).Eq(chi.URLParam(r, "id")))
+	if conds := rs.scopeConds(r); len(conds) > 0 {
+		q = q.Where(conds...)
+	}
+	return q.First(r.Context())
+}

--- a/docs/guide/crud-api.md
+++ b/docs/guide/crud-api.md
@@ -1,0 +1,179 @@
+# JSON CRUD APIs
+
+The `crud` package turns a [Den](database.md) document type into a standard set
+of JSON CRUD endpoints. The common 90% — list, get, create, update, delete — is
+declared; custom actions stay ordinary [chi](routing.md) routes.
+
+## The simple case
+
+A `crud.Resource` is an `http.Handler`. Store your `*den.DB` on the app in
+[`Configure`](configuration.md), then mount a resource the normal chi way with
+`r.Mount`:
+
+```go
+import (
+    "github.com/go-chi/chi/v5"
+    "github.com/oliverandrich/burrow"
+    "github.com/oliverandrich/burrow/contrib/auth"
+    "github.com/oliverandrich/burrow/crud"
+    "github.com/oliverandrich/den"
+)
+
+type App struct {
+    db *den.DB
+}
+
+func (a *App) Configure(cfg *burrow.AppConfig, _ *cli.Command) error {
+    a.db = cfg.DB
+    return nil
+}
+
+func (a *App) Routes(r chi.Router) {
+    r.Route("/api", func(r chi.Router) {
+        r.Use(auth.RequireAuth())                 // gate it like any route
+        r.Mount("/notes", crud.NewResource[Note](a.db))
+    })
+}
+```
+
+`Note` is your Den document type (it embeds `document.Base` — see
+[Database](database.md)). That serves five endpoints under `/api/notes`:
+
+| Method | Path | Action |
+|--------|------|--------|
+| `GET` | `/api/notes` | List (paginated) |
+| `POST` | `/api/notes` | Create → `201` |
+| `GET` | `/api/notes/{id}` | Get |
+| `PUT` / `PATCH` | `/api/notes/{id}` | Update |
+| `DELETE` | `/api/notes/{id}` | Delete → `204` |
+
+Lists use offset [pagination](pagination.md#json-api) and return a
+`burrow.PageResponse[T]` (`{"items": […], "pagination": {…}}`); single resources
+return the document as JSON. Responses are always JSON.
+
+!!! warning "Without a write model, every field is client-settable"
+    The simple case above binds the request body directly onto `Note`, so a
+    client can set *any* field (including `id` or an owner column). That is fine
+    for trusted callers; for untrusted input, add a [write model](#write-models).
+
+## Custom actions
+
+When a resource needs a custom action alongside the generated ones (the 10%),
+register it into a route group with `Routes` and add the extra routes as
+ordinary siblings:
+
+```go
+r.Route("/api/notes", func(r chi.Router) {
+    r.Use(auth.RequireAuth())
+    crud.NewResource[Note](a.db).Routes(r)                // generated: /, /{id}
+    r.Post("/{id}/publish", burrow.Handle(a.publishNote)) // your own route
+})
+```
+
+`res.Routes(r)` reads just like your app's own `Routes` method — no new routing
+concept. (`r.Mount` is the shorthand for the no-custom-actions case; because a
+mounted handler is a sealed subtree, sibling routes must be registered next to
+it with `Routes` instead.)
+
+## Ownership and tenancy
+
+`WithScope` narrows **every** action to the conditions you return for the
+request, using Den's [`where`](database.md) package
+(`github.com/oliverandrich/den/where`). It applies to list, get, update, and
+delete alike, so a client cannot reach another user's row by guessing its id —
+single-row lookups `404` instead of leaking:
+
+```go
+crud.NewResource[Note](a.db,
+    crud.WithScope[Note](func(r *http.Request) []where.Condition {
+        u := auth.MustCurrentUser[Profile](r.Context())
+        return []where.Condition{where.Field("author_id").Eq(u.ID)}
+    }),
+)
+```
+
+(`Profile` is your [auth profile type](../contrib/auth.md), or
+`auth.EmptyProfile`.)
+
+## Write models
+
+`WithCreate` / `WithUpdate` take a typed write model: only its fields are
+accepted (validated against their [`validate`](validation.md) tags), and you map
+it onto the document yourself — so clients can't set server-owned fields:
+
+```go
+type createNote struct {
+    Title string `json:"title" validate:"required"`
+    Body  string `json:"body"`
+}
+
+crud.NewResource[Note](a.db,
+    crud.WithCreate(func(in createNote, r *http.Request) (*Note, error) {
+        u := auth.MustCurrentUser[Profile](r.Context())
+        return &Note{AuthorID: u.ID, Title: in.Title, Body: in.Body}, nil
+    }),
+    crud.WithUpdate(func(in createNote, n *Note, r *http.Request) error {
+        n.Title, n.Body = in.Title, in.Body
+        return nil
+    }),
+)
+```
+
+Without these, the body binds directly onto the document (the simple case).
+
+## Output shaping
+
+By default the stored document is marshalled as-is — which exposes every field,
+including ones you add later. `WithPresenter` maps each document to an explicit
+output shape:
+
+```go
+crud.WithPresenter(func(n *Note) any {
+    return map[string]any{"id": n.ID, "title": n.Title}
+})
+```
+
+## Other options
+
+- `WithSort(field, den.Asc|den.Desc)` — default list ordering (creation time
+  descending when unset). `field` is the JSON field name, e.g. `"title"`.
+- `Only(crud.ActionList, crud.ActionGet)` / `Except(crud.ActionDelete)` — expose
+  a subset of the five actions. Disable a standard action and write your own
+  sibling route to fully replace it.
+
+## Authentication and CSRF
+
+`crud` is auth-agnostic — gate a resource with ordinary middleware
+([`auth.RequireAuth`](../contrib/auth.md), `RequireStaff`, …) via `r.Use`,
+exactly like any route. Mounting without a gate leaves the endpoints open, just
+as a hand-written route would.
+
+API clients authenticate with
+[API-key bearer tokens](../contrib/auth.md#api-key-authentication) rather than
+cookies, so they must send `Accept: application/json` (it makes an
+unauthenticated request return `401` instead of a login redirect) and the API
+prefix needs a [CSRF exemption](../contrib/csrf.md#exempting-webhook-paths) for
+unsafe methods. Returning the prefix from `CSRFExemptPaths` is all it takes —
+the csrf app discovers the method automatically; the trailing slash makes it a
+prefix match:
+
+```go
+func (a *App) CSRFExemptPaths() []string { return []string{"/api/"} }
+```
+
+```bash
+curl -H "Authorization: Bearer brw_…" -H "Accept: application/json" \
+     -H "Content-Type: application/json" -d '{"title":"Hello"}' \
+     https://example.com/api/notes
+```
+
+## Errors
+
+Failures use one envelope, always JSON:
+
+```json
+{ "error": { "code": "validation_failed", "fields": { "title": "is required" } } }
+```
+
+`code` is `validation_failed` (400, with localized `fields`), `invalid_request`
+(400, malformed body), `not_found` (404), or `internal` (500).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
           - Validation: guide/validation.md
           - Internationalization: guide/i18n.md
       - Advanced:
+          - JSON CRUD APIs: guide/crud-api.md
           - Pagination: guide/pagination.md
           - Full-Text Search: guide/fts5.md
           - File Uploads: guide/uploader.md


### PR DESCRIPTION
## Summary

Adds a `crud` package that turns a Den document type into the five standard JSON CRUD endpoints, so the common 90% of an API can be declared while custom actions stay ordinary chi routes.

- `crud.NewResource[T](db, opts...)` returns a `*Resource[T]` that **is an `http.Handler`** — mount it the normal chi way with `r.Mount("/notes", res)`, or register it into a route group with `res.Routes(r)` to add custom sibling actions (e.g. `POST /{id}/publish`). One routing concept; no inverted vocabulary.
- Endpoints: `GET /` (paginated list → `PageResponse[T]`), `POST /` (201), `GET /{id}`, `PUT`/`PATCH /{id}`, `DELETE /{id}` (204).
- Options (all `Option[T]`, like the `forms` package): `WithScope` (ownership/tenancy, applied to **every** action so id-guessing 404s instead of leaking), `WithCreate`/`WithUpdate` (typed write models, DTO type inferred — mass-assignment protection), `WithPresenter` (output shaping), `WithSort`, `Only`/`Except`.
- Errors use one JSON envelope: `{"error":{"code","fields"}}` — `validation_failed` (400, localized), `invalid_request` (400), `not_found` (404), `internal` (500).
- Auth and CSRF are the host's ordinary middleware (`r.Use(auth.RequireAuth())`, `CSRFExemptPaths`); `crud` is representation-agnostic and JSON-only.

## Test plan

- `go test ./...` — green, incl. crud tests for list/pagination/scope, get (404 + scope-hides-others), create (bind + DTO mass-assignment block + validation 400 + bad-JSON 400), update (PUT/PATCH + DTO), delete (204), presenter, `Only`, and `Routes(r)` + custom sibling coexistence.
- `golangci-lint run ./...` — clean.
- `mise run docs-build` — no issues; new [JSON CRUD APIs guide](docs/guide/crud-api.md).