### PR TITLE
feat(example): notes JSON API via crud

### DIFF
--- a/example/notes/internal/notes/api.go
+++ b/example/notes/internal/notes/api.go
@@ -1,0 +1,57 @@
+package notes
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/oliverandrich/burrow/contrib/auth"
+	"github.com/oliverandrich/burrow/crud"
+	"github.com/oliverandrich/den/where"
+)
+
+// noteInput is the API write model. It omits UserID on purpose — ownership
+// comes from the authenticated user, never the client (mass-assignment guard).
+type noteInput struct {
+	Title   string `json:"title" validate:"required"`
+	Content string `json:"content"`
+}
+
+// apiRoutes mounts the JSON CRUD API for notes under /api/notes. It is the
+// machine-facing counterpart to the HTML UI: gated by RequireAuth (which now
+// also accepts API-key bearer tokens) and scoped to the current user, so each
+// caller only ever sees and edits their own notes. For a custom action
+// alongside these (e.g. POST /api/notes/{id}/publish), swap r.Mount for
+// crud.NewResource(...).Routes(r) and add the route as a sibling — see
+// docs/guide/crud-api.md.
+func (a *App) apiRoutes(r chi.Router) {
+	r.Route("/api", func(r chi.Router) {
+		r.Use(auth.RequireAuth())
+		r.Mount("/notes", crud.NewResource[Note](a.db,
+			// Scope narrows every action to the caller's own notes.
+			crud.WithScope[Note](func(req *http.Request) []where.Condition {
+				return []where.Condition{where.Field("user_id").Eq(currentUserID(req))}
+			}),
+			// WithCreate stamps the owner on new records from the auth context.
+			crud.WithCreate(func(in noteInput, req *http.Request) (*Note, error) {
+				return &Note{UserID: currentUserID(req), Title: in.Title, Content: in.Content}, nil
+			}),
+			crud.WithUpdate(func(in noteInput, n *Note, _ *http.Request) error {
+				n.Title, n.Content = in.Title, in.Content
+				return nil
+			}),
+		))
+	})
+}
+
+// CSRFExemptPaths exempts the bearer-authenticated JSON API from CSRF — it
+// carries no cookie, so there is no CSRF token to check. The csrf app discovers
+// this method automatically at boot. The trailing slash makes "/api/" a prefix
+// match (covers /api/notes, /api/notes/{id}); "/api" with no slash would match
+// nothing, since no route is literally /api.
+func (a *App) CSRFExemptPaths() []string { return []string{"/api/"} }
+
+// currentUserID returns the authenticated user's id; the API routes are behind
+// RequireAuth, so a user is always present.
+func currentUserID(r *http.Request) string {
+	return auth.MustCurrentUser[Profile](r.Context()).ID
+}

--- a/example/notes/internal/notes/api_test.go
+++ b/example/notes/internal/notes/api_test.go
@@ -1,0 +1,107 @@
+package notes
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/contrib/auth"
+	"github.com/oliverandrich/den"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apiRouter mounts the notes JSON API behind a middleware that authenticates
+// every request as testUser() (user-42), standing in for RequireAuth.
+func apiRouter(t *testing.T, db *den.DB) chi.Router {
+	t.Helper()
+	app := &App{repo: NewRepository(db), db: db}
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			next.ServeHTTP(w, req.WithContext(auth.WithUser(req.Context(), testUser())))
+		})
+	})
+	app.apiRoutes(r)
+	return r
+}
+
+func apiDo(t *testing.T, h http.Handler, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req := httptest.NewRequestWithContext(t.Context(), method, target, rdr)
+	req.Header.Set("Accept", "application/json")
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAPICRUDRoundTrip(t *testing.T) {
+	r := apiRouter(t, openTestDB(t))
+
+	// Create — UserID is taken from the auth context, not the request body.
+	rec := apiDo(t, r, http.MethodPost, "/api/notes", `{"title":"First","content":"hello","user_id":"hacker"}`)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var created Note
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	assert.Equal(t, "user-42", created.UserID, "owner comes from the authenticated user")
+	assert.Equal(t, "First", created.Title)
+
+	// List.
+	rec = apiDo(t, r, http.MethodGet, "/api/notes", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list burrow.PageResponse[Note]
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list.Items, 1)
+
+	// Get.
+	rec = apiDo(t, r, http.MethodGet, "/api/notes/"+created.ID, "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Update, then read it back to confirm the change landed.
+	rec = apiDo(t, r, http.MethodPut, "/api/notes/"+created.ID, `{"title":"Renamed","content":"x"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rec = apiDo(t, r, http.MethodGet, "/api/notes/"+created.ID, "")
+	var reloaded Note
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &reloaded))
+	assert.Equal(t, "Renamed", reloaded.Title)
+
+	// Delete.
+	rec = apiDo(t, r, http.MethodDelete, "/api/notes/"+created.ID, "")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Gone.
+	rec = apiDo(t, r, http.MethodGet, "/api/notes/"+created.ID, "")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestAPIRejectsMissingTitle(t *testing.T) {
+	r := apiRouter(t, openTestDB(t))
+
+	rec := apiDo(t, r, http.MethodPost, "/api/notes", `{"content":"no title"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "validation_failed")
+}
+
+func TestAPIScopedToOwner(t *testing.T) {
+	db := openTestDB(t)
+	// A note owned by someone else must stay invisible to user-42.
+	require.NoError(t, den.Save(context.Background(), db, &Note{UserID: "other", Title: "secret"}))
+
+	rec := apiDo(t, apiRouter(t, db), http.MethodGet, "/api/notes", "")
+	var list burrow.PageResponse[Note]
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	assert.Empty(t, list.Items, "the scope hides other users' notes")
+}

--- a/example/notes/internal/notes/app.go
+++ b/example/notes/internal/notes/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oliverandrich/burrow"
 	"github.com/oliverandrich/burrow/contrib/auth"
 	"github.com/oliverandrich/burrow/contrib/htmx"
+	"github.com/oliverandrich/den"
 	"github.com/oliverandrich/den/document"
 	"github.com/urfave/cli/v3"
 )
@@ -26,6 +27,7 @@ var noteTemplateFS embed.FS
 type App struct {
 	repo     *Repository
 	userRepo *auth.Repository[Profile]
+	db       *den.DB
 }
 
 // New creates a new notes app.
@@ -40,6 +42,7 @@ func (a *App) Dependencies() []string { return []string{"auth"} }
 func (a *App) Configure(cfg *burrow.AppConfig, _ *cli.Command) error {
 	a.repo = NewRepository(cfg.DB)
 	a.userRepo = auth.NewRepository[Profile](cfg.DB)
+	a.db = cfg.DB
 	return nil
 }
 
@@ -99,6 +102,9 @@ func (a *App) Routes(r chi.Router) {
 		r.Post("/{id}", burrow.Handle(a.Update))
 		r.Delete("/{id}", burrow.Handle(a.Delete))
 	})
+
+	// JSON API counterpart to the HTML UI above (see api.go).
+	a.apiRoutes(r)
 }
 
 // adminListNotes handles GET /admin/notes — paginated note list with optional search.


### PR DESCRIPTION
## Summary

Demonstrates the new `crud` package end-to-end in the `notes` example app by adding a JSON API alongside the existing HTML UI.

- `/api/notes` is mounted with `r.Mount` behind `auth.RequireAuth()` (now bearer-capable), scoped to the authenticated user so each caller only sees and edits their own notes.
- A `noteInput` write model keeps `UserID` server-owned (set from the auth context, not the request body) — the mass-assignment guard the guide describes.
- `CSRFExemptPaths()` exempts the cookie-less bearer API prefix; the example also doubles as the worked reference for the [JSON CRUD APIs guide](https://burrow.andrich.dev/guide/crud-api/).

## Test plan

- `go test ./...` — green, incl. new integration tests: CRUD round-trip (create→list→get→update→delete), `user_id` injection (body value ignored), validation rejection (400 `validation_failed`), and owner-scope isolation (another user's note stays invisible).
- `golangci-lint run ./...` — clean.