### PR TITLE
refactor(auth): drop the Renderer interface for template overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ## Unreleased
 
+### Breaking Changes
+
+- **contrib/auth: the `Renderer` interface and `WithRenderer` option are removed.** Auth pages now render directly through their named templates; customize a page by redefining its template block (`{{ define "auth/login" }}` …, last-define-wins) instead of implementing a renderer. `WithAuthLayout` is unchanged. Migrating off a custom `Renderer` means deleting the `auth.WithRenderer(...)` call and moving any markup changes into template overrides.
+
 ### Added
 
 - **`crud` package: declarative JSON CRUD APIs.** `crud.NewResource[T](db, opts…)` turns a Den document type into the five standard endpoints (list/get/create/update/delete) as a plain `http.Handler` — mount it with `r.Mount`, or register it into a route group with `Routes(r)` to add custom sibling actions. Options cover ownership scoping (`WithScope`, applied to every action), typed write models (`WithCreate`/`WithUpdate`, mass-assignment-safe), output shaping (`WithPresenter`), sorting, and action subsetting (`Only`/`Except`). Auth and CSRF stay the host's ordinary middleware. See the [JSON CRUD APIs guide](https://burrow.andrich.dev/guide/crud-api/).
@@ -824,7 +828,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 - Added "Why urfave/cli?" section to [Server & Registry](reference/server.md) reference.
 - New guide: [Testing](guide/testing.md) covering test helpers and patterns.
 - New pages: [Examples & Tutorial](getting-started/examples.md) overview, seven-part [Tutorial](tutorial/index.md).
-- Expanded auth [Renderer](contrib/auth.md#renderer) and [Auth Layout](contrib/auth.md#auth-layout) documentation with usage examples.
+- Expanded auth [page rendering](contrib/auth.md#page-rendering) and [Auth Layout](contrib/auth.md#auth-layout) documentation with usage examples.
 - **Default email renderer moved** from `authmail/smtpmail/templates` to `auth.DefaultEmailRenderer()`. The `authmail` package keeps the `Renderer` interface only.
 - Auth app now declares `i18n` as a dependency alongside `session`.
 - Added `i18n.NewTestApp()` helper for creating a minimal i18n setup in tests.

--- a/contrib/auth/app.go
+++ b/contrib/auth/app.go
@@ -77,7 +77,6 @@ type App[P any] struct {
 	repo           *Repository[P]
 	webauthn       WebAuthnService
 	recovery       *RecoveryService
-	renderer       Renderer
 	emailService   EmailService
 	authLayout     string
 	defaultRole    string
@@ -105,11 +104,6 @@ type Config struct {
 
 // Option configures the auth app.
 type Option[P any] func(*App[P])
-
-// WithRenderer sets the page renderer for auth views.
-func WithRenderer[P any](r Renderer) Option[P] {
-	return func(a *App[P]) { a.renderer = r }
-}
 
 // WithAuthLayout sets an optional layout template name for public (unauthenticated)
 // auth pages. When set, pages like login, register, and recovery use this layout
@@ -185,11 +179,10 @@ func validateDefaultRole(role string) error {
 }
 
 // New creates a new auth app with the given options.
-// By default, the built-in HTML renderer and auth layout are used.
-// Use WithRenderer() and WithAuthLayout() to override.
+// By default, the built-in auth layout is used; override it with
+// [WithAuthLayout], or restyle any page by redefining its template.
 func New[P any](opts ...Option[P]) *App[P] {
 	a := &App[P]{
-		renderer:   DefaultRenderer(),
 		authLayout: DefaultAuthLayout(),
 	}
 	for _, o := range opts {

--- a/contrib/auth/app_test.go
+++ b/contrib/auth/app_test.go
@@ -1360,13 +1360,21 @@ func TestNewWithoutValidators(t *testing.T) {
 	assert.Nil(t, app.emailValidator, "emailValidator must be nil by default")
 }
 
+// layoutCapturingExecutor returns a TemplateExecutor that records the layout
+// present in context (set by authLayoutMiddleware) into capturedLayout and
+// renders trivial text. It replaces the former layoutCapturingRenderer now
+// that page rendering goes through the package funcs + a context executor.
+func layoutCapturingExecutor(capturedLayout *string) burrow.TemplateExecutor {
+	return func(ctx context.Context, _ string, _ map[string]any) (template.HTML, error) {
+		*capturedLayout = burrow.Layout(ctx)
+		return template.HTML("page"), nil //nolint:gosec // test
+	}
+}
+
 func TestPublicAuthRoutesUseAuthLayout(t *testing.T) {
-	// Set up a mock renderer that captures the layout from context.
 	var capturedLayout string
-	mockR := &layoutCapturingRenderer{capturedLayout: &capturedLayout}
 
 	app := &App[EmptyProfile]{
-		renderer:   mockR,
 		config:     &Config{LoginRedirect: "/"},
 		authLayout: "test/auth-layout",
 	}
@@ -1375,6 +1383,7 @@ func TestPublicAuthRoutesUseAuthLayout(t *testing.T) {
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := burrow.WithLayout(r.Context(), "global/layout")
+			ctx = burrow.WithTemplateExecutor(ctx, layoutCapturingExecutor(&capturedLayout))
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	})
@@ -1386,20 +1395,17 @@ func TestPublicAuthRoutesUseAuthLayout(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	// The captured layout should be the auth layout, not the global one.
-	assert.Equal(t, "test/auth-layout", *mockR.capturedLayout, "layout should be the auth layout")
+	assert.Equal(t, "test/auth-layout", capturedLayout, "layout should be the auth layout")
 }
 
 func TestAuthenticatedRoutesKeepGlobalLayout(t *testing.T) {
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)
 
-	// Set up a mock renderer that captures the layout from context.
 	var capturedLayout string
-	mockR := &layoutCapturingRenderer{capturedLayout: &capturedLayout}
 
 	app := &App[EmptyProfile]{
 		repo:       repo,
-		renderer:   mockR,
 		config:     &Config{LoginRedirect: "/"},
 		authLayout: "test/auth-layout",
 	}
@@ -1412,6 +1418,7 @@ func TestAuthenticatedRoutesKeepGlobalLayout(t *testing.T) {
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := burrow.WithLayout(r.Context(), "global/layout")
+			ctx = burrow.WithTemplateExecutor(ctx, layoutCapturingExecutor(&capturedLayout))
 			// Inject the user so RequireAuth passes.
 			ctx = WithUser(ctx, user)
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -1425,17 +1432,15 @@ func TestAuthenticatedRoutesKeepGlobalLayout(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	// The captured layout should be the global layout, not the auth layout.
-	assert.Equal(t, "global/layout", *mockR.capturedLayout, "layout should be the global layout")
+	assert.Equal(t, "global/layout", capturedLayout, "layout should be the global layout")
 }
 
 func TestPublicRoutesWithoutAuthLayoutKeepGlobalLayout(t *testing.T) {
 	// When no auth layout is set, public routes should keep the global layout.
 	var capturedLayout string
-	mockR := &layoutCapturingRenderer{capturedLayout: &capturedLayout}
 
 	app := &App[EmptyProfile]{
-		renderer: mockR,
-		config:   &Config{LoginRedirect: "/"},
+		config: &Config{LoginRedirect: "/"},
 	}
 	// No SetAuthLayout call.
 
@@ -1443,6 +1448,7 @@ func TestPublicRoutesWithoutAuthLayoutKeepGlobalLayout(t *testing.T) {
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := burrow.WithLayout(r.Context(), "global/layout")
+			ctx = burrow.WithTemplateExecutor(ctx, layoutCapturingExecutor(&capturedLayout))
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	})
@@ -1453,60 +1459,7 @@ func TestPublicRoutesWithoutAuthLayoutKeepGlobalLayout(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "global/layout", *mockR.capturedLayout, "global layout should be preserved when no auth layout is set")
-}
-
-// layoutCapturingRenderer is a mock Renderer that captures the layout from context.
-type layoutCapturingRenderer struct {
-	capturedLayout *string
-}
-
-func (m *layoutCapturingRenderer) LoginPage(w http.ResponseWriter, r *http.Request, _ string) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "login")
-}
-
-func (m *layoutCapturingRenderer) RegisterPage(w http.ResponseWriter, r *http.Request, _, _ bool, _, _ string) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "register")
-}
-
-func (m *layoutCapturingRenderer) CredentialsPage(w http.ResponseWriter, r *http.Request, _ []Credential) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "credentials")
-}
-
-func (m *layoutCapturingRenderer) RecoveryPage(w http.ResponseWriter, r *http.Request, _ string) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "recovery")
-}
-
-func (m *layoutCapturingRenderer) RecoveryCodesPage(w http.ResponseWriter, r *http.Request, _ []string) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "recovery-codes")
-}
-
-func (m *layoutCapturingRenderer) VerifyPendingPage(w http.ResponseWriter, r *http.Request) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "verify-pending")
-}
-
-func (m *layoutCapturingRenderer) VerifyEmailSuccessPage(w http.ResponseWriter, r *http.Request) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusOK, "verify-success")
-}
-
-func (m *layoutCapturingRenderer) VerifyEmailErrorPage(w http.ResponseWriter, r *http.Request, _ string) error {
-	lay := burrow.Layout(r.Context())
-	*m.capturedLayout = lay
-	return burrow.Text(w, http.StatusBadRequest, "verify-error")
+	assert.Equal(t, "global/layout", capturedLayout, "global layout should be preserved when no auth layout is set")
 }
 
 // --- Static files tests ---
@@ -1579,12 +1532,6 @@ func TestRequestFuncMapUnauthenticated(t *testing.T) {
 }
 
 // --- Option functions ---
-
-func TestWithRendererOption(t *testing.T) {
-	r := &mockRenderer{}
-	app := New[EmptyProfile](WithRenderer[EmptyProfile](r))
-	assert.Equal(t, r, app.renderer)
-}
 
 func TestWithLogoComponentOption(t *testing.T) {
 	logo := template.HTML(`<img src="logo.png"/>`)
@@ -1831,18 +1778,15 @@ func TestRequestFuncMapAuthLogo(t *testing.T) {
 }
 
 func TestNewWithMultipleOptions(t *testing.T) {
-	r := &mockRenderer{}
 	logo := template.HTML(`<span>Logo</span>`)
 	emailSvc := &mockEmailService{}
 
 	app := New(
-		WithRenderer[EmptyProfile](r),
 		WithLogoComponent[EmptyProfile](logo),
 		WithEmailService[EmptyProfile](emailSvc),
 		WithAuthLayout[EmptyProfile]("custom/auth-layout"),
 	)
 
-	assert.Equal(t, r, app.renderer)
 	assert.Equal(t, logo, app.logo)
 	assert.Equal(t, emailSvc, app.emailService)
 	assert.Equal(t, "custom/auth-layout", app.authLayout)
@@ -1863,12 +1807,19 @@ func TestAdminRoutes(t *testing.T) {
 
 func TestRoutesWithLogoMiddleware(t *testing.T) {
 	app := &App[EmptyProfile]{
-		renderer: &mockRenderer{},
-		config:   &Config{LoginRedirect: "/"},
-		logo:     template.HTML(`<img src="logo.png"/>`),
+		config: &Config{LoginRedirect: "/"},
+		logo:   template.HTML(`<img src="logo.png"/>`),
 	}
 
 	router := chi.NewRouter()
+	// Inject a template executor so the login page renders instead of
+	// falling through to burrow.Render (which needs a template set).
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := burrow.WithTemplateExecutor(r.Context(), rendererTestExecutor())
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
 	// Should not panic.
 	app.Routes(router)
 

--- a/contrib/auth/handlers_credentials.go
+++ b/contrib/auth/handlers_credentials.go
@@ -15,7 +15,7 @@ func (a *App[P]) CredentialsPage(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errorJSONLog(w, http.StatusInternalServerError, "failed to get credentials", err)
 	}
-	return a.renderer.CredentialsPage(w, r, creds)
+	return credentialsPage(w, r, creds)
 }
 
 // AddCredentialBegin starts the process of adding a new credential.

--- a/contrib/auth/handlers_email.go
+++ b/contrib/auth/handlers_email.go
@@ -11,14 +11,14 @@ import (
 
 // VerifyPendingPage renders the "check your email" page.
 func (a *App[P]) VerifyPendingPage(w http.ResponseWriter, r *http.Request) error {
-	return a.renderer.VerifyPendingPage(w, r)
+	return verifyPendingPage(w, r)
 }
 
 // VerifyEmail handles the email verification link.
 func (a *App[P]) VerifyEmail(w http.ResponseWriter, r *http.Request) error {
 	token := r.URL.Query().Get("token")
 	if token == "" {
-		return a.renderer.VerifyEmailErrorPage(w, r, "missing_token")
+		return verifyEmailErrorPage(w, r, "missing_token")
 	}
 
 	ctx := r.Context()
@@ -26,19 +26,19 @@ func (a *App[P]) VerifyEmail(w http.ResponseWriter, r *http.Request) error {
 
 	verificationToken, err := a.repo.GetEmailVerificationToken(ctx, tokenHash)
 	if err != nil {
-		return a.renderer.VerifyEmailErrorPage(w, r, "invalid_token")
+		return verifyEmailErrorPage(w, r, "invalid_token")
 	}
 
 	if time.Now().After(verificationToken.ExpiresAt) {
 		if delErr := a.repo.DeleteEmailVerificationToken(ctx, verificationToken.ID); delErr != nil {
 			slog.Error("failed to delete expired verification token", "token_id", verificationToken.ID, "error", delErr)
 		}
-		return a.renderer.VerifyEmailErrorPage(w, r, "token_expired")
+		return verifyEmailErrorPage(w, r, "token_expired")
 	}
 
 	if markErr := a.repo.MarkEmailVerified(ctx, verificationToken.UserID); markErr != nil {
 		slog.Error("failed to mark email as verified", "error", markErr)
-		return a.renderer.VerifyEmailErrorPage(w, r, "verification_failed")
+		return verifyEmailErrorPage(w, r, "verification_failed")
 	}
 
 	if delErr := a.repo.DeleteUserEmailVerificationTokens(ctx, verificationToken.UserID); delErr != nil {
@@ -48,15 +48,15 @@ func (a *App[P]) VerifyEmail(w http.ResponseWriter, r *http.Request) error {
 	user, err := a.repo.GetUserByID(ctx, verificationToken.UserID)
 	if err != nil {
 		slog.Error("failed to get user after verification", "error", err)
-		return a.renderer.VerifyEmailErrorPage(w, r, "verification_failed")
+		return verifyEmailErrorPage(w, r, "verification_failed")
 	}
 
 	if err := session.Save(w, r, map[string]any{"user_id": user.ID}); err != nil {
 		slog.Error("failed to create session after verification", "error", err)
-		return a.renderer.VerifyEmailErrorPage(w, r, "verification_failed")
+		return verifyEmailErrorPage(w, r, "verification_failed")
 	}
 
-	return a.renderer.VerifyEmailSuccessPage(w, r)
+	return verifyEmailSuccessPage(w, r)
 }
 
 // ResendVerificationRequest is the request body for resending verification email.

--- a/contrib/auth/handlers_login.go
+++ b/contrib/auth/handlers_login.go
@@ -16,7 +16,7 @@ import (
 
 // LoginPage renders the login page.
 func (a *App[P]) LoginPage(w http.ResponseWriter, r *http.Request) error {
-	return a.renderer.LoginPage(w, r, a.config.LoginRedirect)
+	return loginPage(w, r, a.config.LoginRedirect)
 }
 
 // LoginBegin starts the WebAuthn discoverable login process.

--- a/contrib/auth/handlers_recovery.go
+++ b/contrib/auth/handlers_recovery.go
@@ -18,7 +18,7 @@ type RecoveryLoginRequest struct {
 
 // RecoveryPage renders the recovery login page.
 func (a *App[P]) RecoveryPage(w http.ResponseWriter, r *http.Request) error {
-	return a.renderer.RecoveryPage(w, r, a.config.LoginRedirect)
+	return recoveryPage(w, r, a.config.LoginRedirect)
 }
 
 // RecoveryLogin authenticates a user with a recovery code.
@@ -130,7 +130,7 @@ func (a *App[P]) RecoveryCodesPage(w http.ResponseWriter, r *http.Request) error
 		return nil
 	}
 
-	return a.renderer.RecoveryCodesPage(w, r, codes)
+	return recoveryCodesPage(w, r, codes)
 }
 
 // AcknowledgeRecoveryCodes clears recovery codes from the session and redirects.

--- a/contrib/auth/handlers_registration.go
+++ b/contrib/auth/handlers_registration.go
@@ -9,19 +9,6 @@ import (
 	"github.com/oliverandrich/burrow/contrib/session"
 )
 
-// Renderer defines the page rendering interface for auth templates.
-// Projects implement this to provide their own template rendering.
-type Renderer interface {
-	RegisterPage(w http.ResponseWriter, r *http.Request, useEmail, inviteOnly bool, email, invite string) error
-	LoginPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error
-	CredentialsPage(w http.ResponseWriter, r *http.Request, creds []Credential) error
-	RecoveryPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error
-	RecoveryCodesPage(w http.ResponseWriter, r *http.Request, codes []string) error
-	VerifyPendingPage(w http.ResponseWriter, r *http.Request) error
-	VerifyEmailSuccessPage(w http.ResponseWriter, r *http.Request) error
-	VerifyEmailErrorPage(w http.ResponseWriter, r *http.Request, errorCode string) error
-}
-
 // UseEmailMode returns true if email-based authentication is enabled.
 func (a *App[P]) UseEmailMode() bool {
 	return a.config != nil && a.config.UseEmail
@@ -47,12 +34,12 @@ func (a *App[P]) RegisterPage(w http.ResponseWriter, r *http.Request) error {
 	if a.IsInviteOnly() && inviteToken != "" {
 		invite, err := a.validateInviteToken(r.Context(), inviteToken)
 		if err != nil || !invite.IsValid() {
-			return a.renderer.RegisterPage(w, r, a.UseEmailMode(), true, "", "")
+			return registerPage(w, r, a.UseEmailMode(), true, "", "")
 		}
-		return a.renderer.RegisterPage(w, r, a.UseEmailMode(), true, invite.Email, inviteToken)
+		return registerPage(w, r, a.UseEmailMode(), true, invite.Email, inviteToken)
 	}
 
-	return a.renderer.RegisterPage(w, r, a.UseEmailMode(), a.IsInviteOnly(), "", "")
+	return registerPage(w, r, a.UseEmailMode(), a.IsInviteOnly(), "", "")
 }
 
 // RegisterBegin starts the WebAuthn registration process.

--- a/contrib/auth/handlers_test.go
+++ b/contrib/auth/handlers_test.go
@@ -28,50 +28,6 @@ func testUserWithID() *User[EmptyProfile] {
 
 // --- Mocks ---
 
-type mockRenderer struct {
-	lastMethod string
-}
-
-func (m *mockRenderer) RegisterPage(w http.ResponseWriter, _ *http.Request, _, _ bool, _, _ string) error {
-	m.lastMethod = "RegisterPage"
-	return burrow.Text(w, http.StatusOK, "register")
-}
-
-func (m *mockRenderer) LoginPage(w http.ResponseWriter, _ *http.Request, _ string) error {
-	m.lastMethod = "LoginPage"
-	return burrow.Text(w, http.StatusOK, "login")
-}
-
-func (m *mockRenderer) CredentialsPage(w http.ResponseWriter, _ *http.Request, _ []Credential) error {
-	m.lastMethod = "CredentialsPage"
-	return burrow.Text(w, http.StatusOK, "credentials")
-}
-
-func (m *mockRenderer) RecoveryPage(w http.ResponseWriter, _ *http.Request, _ string) error {
-	m.lastMethod = "RecoveryPage"
-	return burrow.Text(w, http.StatusOK, "recovery")
-}
-
-func (m *mockRenderer) RecoveryCodesPage(w http.ResponseWriter, _ *http.Request, _ []string) error {
-	m.lastMethod = "RecoveryCodesPage"
-	return burrow.Text(w, http.StatusOK, "recovery-codes")
-}
-
-func (m *mockRenderer) VerifyPendingPage(w http.ResponseWriter, _ *http.Request) error {
-	m.lastMethod = "VerifyPendingPage"
-	return burrow.Text(w, http.StatusOK, "verify-pending")
-}
-
-func (m *mockRenderer) VerifyEmailSuccessPage(w http.ResponseWriter, _ *http.Request) error {
-	m.lastMethod = "VerifyEmailSuccessPage"
-	return burrow.Text(w, http.StatusOK, "verify-success")
-}
-
-func (m *mockRenderer) VerifyEmailErrorPage(w http.ResponseWriter, _ *http.Request, _ string) error {
-	m.lastMethod = "VerifyEmailErrorPage"
-	return burrow.Text(w, http.StatusBadRequest, "verify-error")
-}
-
 type mockEmailService struct {
 	sendCalled bool
 }
@@ -100,32 +56,29 @@ func testApp(t *testing.T, bundle *i18n.Bundle) *App[EmptyProfile] {
 	return &App[EmptyProfile]{withLocale: bundle.WithLocale}
 }
 
-func setupTestApp(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile], *mockRenderer) {
+func setupTestApp(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile]) {
 	t.Helper()
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
 	a := testApp(t, testI18nBundle(t))
 	a.repo = repo
 	a.webauthn = waSvc
-	a.renderer = renderer
 	a.config = &Config{
 		LoginRedirect:  "/dashboard",
 		LogoutRedirect: "/auth/login",
 	}
 	a.recovery = NewRecoveryService()
 	a.recovery.BcryptCost = bcrypt.MinCost
-	return a, repo, renderer
+	return a, repo
 }
 
-func setupTestAppEmailMode(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile], *mockRenderer) {
+func setupTestAppEmailMode(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile]) {
 	t.Helper()
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
@@ -134,7 +87,6 @@ func setupTestAppEmailMode(t *testing.T) (*App[EmptyProfile], *Repository[EmptyP
 	a.repo = repo
 	a.webauthn = waSvc
 	a.emailService = emailSvc
-	a.renderer = renderer
 	a.config = &Config{
 		LoginRedirect:       "/dashboard",
 		LogoutRedirect:      "/auth/login",
@@ -144,21 +96,19 @@ func setupTestAppEmailMode(t *testing.T) (*App[EmptyProfile], *Repository[EmptyP
 	}
 	a.recovery = NewRecoveryService()
 	a.recovery.BcryptCost = bcrypt.MinCost
-	return a, repo, renderer
+	return a, repo
 }
 
-func setupTestAppInviteOnly(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile], *mockRenderer) {
+func setupTestAppInviteOnly(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile]) {
 	t.Helper()
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
 	a := testApp(t, testI18nBundle(t))
 	a.repo = repo
 	a.webauthn = waSvc
-	a.renderer = renderer
 	a.config = &Config{
 		LoginRedirect:  "/dashboard",
 		LogoutRedirect: "/auth/login",
@@ -166,17 +116,19 @@ func setupTestAppInviteOnly(t *testing.T) (*App[EmptyProfile], *Repository[Empty
 	}
 	a.recovery = NewRecoveryService()
 	a.recovery.BcryptCost = bcrypt.MinCost
-	return a, repo, renderer
+	return a, repo
 }
 
 // requestWithSession creates a request with session state injected, optionally with a user.
+// It also installs a real template executor in context so page-rendering handlers
+// (loginPage, registerPage, …) produce HTML instead of falling through to burrow.Render.
 func requestWithSession(req *http.Request, user *User[EmptyProfile]) *http.Request {
 	req = session.Inject(req, map[string]any{})
+	ctx := burrow.WithTemplateExecutor(req.Context(), rendererTestExecutor())
 	if user != nil {
-		ctx := WithUser(req.Context(), user)
-		req = req.WithContext(ctx)
+		ctx = WithUser(ctx, user)
 	}
-	return req
+	return req.WithContext(ctx)
 }
 
 // openTestDBClosable opens a test DB that can be closed to trigger database errors in handlers.
@@ -192,14 +144,12 @@ func setupTestAppClosable(t *testing.T) (*App[EmptyProfile], *Repository[EmptyPr
 	t.Helper()
 	db := openTestDBClosable(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
 	a := testApp(t, testI18nBundle(t))
 	a.repo = repo
 	a.webauthn = waSvc
-	a.renderer = renderer
 	a.config = &Config{
 		LoginRedirect:  "/dashboard",
 		LogoutRedirect: "/auth/login",
@@ -214,7 +164,6 @@ func setupTestAppEmailModeClosable(t *testing.T) (*App[EmptyProfile], *Repositor
 	t.Helper()
 	db := openTestDBClosable(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
@@ -223,7 +172,6 @@ func setupTestAppEmailModeClosable(t *testing.T) (*App[EmptyProfile], *Repositor
 	a.repo = repo
 	a.webauthn = waSvc
 	a.emailService = emailSvc
-	a.renderer = renderer
 	a.config = &Config{
 		LoginRedirect:       "/dashboard",
 		LogoutRedirect:      "/auth/login",
@@ -239,26 +187,26 @@ func setupTestAppEmailModeClosable(t *testing.T) (*App[EmptyProfile], *Repositor
 // --- Handler creation tests ---
 
 func TestAppSetup(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	assert.NotNil(t, h)
 	assert.False(t, h.UseEmailMode())
 	assert.False(t, h.IsInviteOnly())
 }
 
 func TestAppSetupEmailMode(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	assert.True(t, h.UseEmailMode())
 }
 
 func TestAppSetupInviteOnly(t *testing.T) {
-	h, _, _ := setupTestAppInviteOnly(t)
+	h, _ := setupTestAppInviteOnly(t)
 	assert.True(t, h.IsInviteOnly())
 }
 
 // --- RegisterPage tests ---
 
 func TestRegisterPage(t *testing.T) {
-	h, _, r := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/register", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -267,11 +215,11 @@ func TestRegisterPage(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "RegisterPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "register-username-label")
 }
 
 func TestRegisterPageInviteOnlyNoToken(t *testing.T) {
-	h, _, r := setupTestAppInviteOnly(t)
+	h, _ := setupTestAppInviteOnly(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/register", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -279,11 +227,12 @@ func TestRegisterPageInviteOnlyNoToken(t *testing.T) {
 	err := h.RegisterPage(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "RegisterPage", r.lastMethod)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "register-username-label")
 }
 
 func TestRegisterPageInviteOnlyWithValidToken(t *testing.T) {
-	h, repo, r := setupTestAppInviteOnly(t)
+	h, repo := setupTestAppInviteOnly(t)
 
 	tokenHash := HashToken("validtoken")
 	invite := &Invite{
@@ -300,13 +249,14 @@ func TestRegisterPageInviteOnlyWithValidToken(t *testing.T) {
 	err := h.RegisterPage(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "RegisterPage", r.lastMethod)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "register-username-label")
 }
 
 // --- RegisterBegin tests ---
 
 func TestRegisterBeginUsernameMode(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	body := strings.NewReader(`{"username":"newuser"}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -328,7 +278,7 @@ func TestRegisterBeginUsernameMode(t *testing.T) {
 }
 
 func TestRegisterBeginAppliesDefaultRole(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	ctx := context.Background()
 
 	// Seed an existing admin so the first-user promotion doesn't kick
@@ -356,7 +306,7 @@ func TestRegisterBeginAppliesDefaultRole(t *testing.T) {
 }
 
 func TestRegisterBeginAdminPromotionWinsOverDefaultRole(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	ctx := context.Background()
 
 	// No prior users → the registrant is the first → admin promotion
@@ -380,7 +330,7 @@ func TestRegisterBeginAdminPromotionWinsOverDefaultRole(t *testing.T) {
 }
 
 func TestRegisterBeginDefaultRoleUnsetPreservesRoleUser(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	ctx := context.Background()
 
 	// Seed an existing admin so the first-user promotion is out of the
@@ -407,7 +357,7 @@ func TestRegisterBeginDefaultRoleUnsetPreservesRoleUser(t *testing.T) {
 }
 
 func TestRegisterBeginMissingUsername(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	body := strings.NewReader(`{"username":""}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -422,7 +372,7 @@ func TestRegisterBeginMissingUsername(t *testing.T) {
 }
 
 func TestRegisterBeginUsernameExists(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 
 	_, err := repo.CreateUser(context.Background(), "taken")
 	require.NoError(t, err)
@@ -460,7 +410,7 @@ func postRegisterBegin(t *testing.T, h *App[EmptyProfile], jsonBody string) *htt
 func TestRegisterBeginValidator(t *testing.T) {
 	cases := []struct {
 		name    string
-		setup   func(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile], *mockRenderer)
+		setup   func(t *testing.T) (*App[EmptyProfile], *Repository[EmptyProfile])
 		install func(h *App[EmptyProfile], fn func(context.Context, string) error)
 		body    string
 		stored  string
@@ -483,7 +433,7 @@ func TestRegisterBeginValidator(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name+" rejects", func(t *testing.T) {
-			h, repo, _ := tc.setup(t)
+			h, repo := tc.setup(t)
 			tc.install(h, func(context.Context, string) error { return errors.New("value is not allowed") })
 
 			rec := postRegisterBegin(t, h, tc.body)
@@ -498,7 +448,7 @@ func TestRegisterBeginValidator(t *testing.T) {
 		})
 
 		t.Run(tc.name+" passes", func(t *testing.T) {
-			h, repo, _ := tc.setup(t)
+			h, repo := tc.setup(t)
 			called := false
 			tc.install(h, func(context.Context, string) error { called = true; return nil })
 
@@ -517,7 +467,7 @@ func TestRegisterBeginValidator(t *testing.T) {
 }
 
 func TestRegisterBeginNilUsernameValidatorUnchanged(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	require.Nil(t, h.usernameValidator, "default app must have no username validator")
 
 	rec := postRegisterBegin(t, h, `{"username":"newuser"}`)
@@ -531,7 +481,7 @@ func TestRegisterBeginNilUsernameValidatorUnchanged(t *testing.T) {
 }
 
 func TestRegisterBeginInvalidJSON(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	body := strings.NewReader(`{invalid}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -545,7 +495,7 @@ func TestRegisterBeginInvalidJSON(t *testing.T) {
 }
 
 func TestRegisterBeginUsernameValidatorIgnoredInEmailMode(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	h.usernameValidator = func(_ context.Context, _ string) error {
 		return errors.New("must not run in email mode")
 	}
@@ -557,7 +507,7 @@ func TestRegisterBeginUsernameValidatorIgnoredInEmailMode(t *testing.T) {
 }
 
 func TestRegisterBeginEmailMode(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	body := strings.NewReader(`{"email":"test@example.com"}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -572,7 +522,7 @@ func TestRegisterBeginEmailMode(t *testing.T) {
 }
 
 func TestRegisterBeginEmailModeMissingEmail(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	body := strings.NewReader(`{"email":""}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/begin", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -587,7 +537,7 @@ func TestRegisterBeginEmailModeMissingEmail(t *testing.T) {
 }
 
 func TestRegisterBeginEmailModeEmailExists(t *testing.T) {
-	h, repo, _ := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 
 	_, err := repo.CreateUserWithEmail(context.Background(), "taken@example.com")
 	require.NoError(t, err)
@@ -607,7 +557,7 @@ func TestRegisterBeginEmailModeEmailExists(t *testing.T) {
 }
 
 func TestRegisterBeginInviteOnlyNoToken(t *testing.T) {
-	h, repo, _ := setupTestAppInviteOnly(t)
+	h, repo := setupTestAppInviteOnly(t)
 
 	// Create a user so first-user bypass doesn't apply.
 	_, err := repo.CreateUser(context.Background(), "existing")
@@ -626,7 +576,7 @@ func TestRegisterBeginInviteOnlyNoToken(t *testing.T) {
 }
 
 func TestRegisterBeginInviteOnlyFirstUserBypass(t *testing.T) {
-	h, _, _ := setupTestAppInviteOnly(t)
+	h, _ := setupTestAppInviteOnly(t)
 
 	// No users exist - first user bypasses invite requirement.
 	body := strings.NewReader(`{"username":"firstuser"}`)
@@ -643,7 +593,7 @@ func TestRegisterBeginInviteOnlyFirstUserBypass(t *testing.T) {
 }
 
 func TestRegisterBeginInviteOnlyValidToken(t *testing.T) {
-	h, repo, _ := setupTestAppInviteOnly(t)
+	h, repo := setupTestAppInviteOnly(t)
 
 	// Create existing user and invite.
 	admin, err := repo.CreateUser(context.Background(), "admin")
@@ -670,7 +620,7 @@ func TestRegisterBeginInviteOnlyValidToken(t *testing.T) {
 }
 
 func TestRegisterBeginInviteOnlyExpiredToken(t *testing.T) {
-	h, repo, _ := setupTestAppInviteOnly(t)
+	h, repo := setupTestAppInviteOnly(t)
 
 	admin, err := repo.CreateUser(context.Background(), "admin")
 	require.NoError(t, err)
@@ -697,7 +647,7 @@ func TestRegisterBeginInviteOnlyExpiredToken(t *testing.T) {
 // --- RegisterFinish tests ---
 
 func TestRegisterFinishInvalidUserID(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/finish?user_id=invalid", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -711,7 +661,7 @@ func TestRegisterFinishInvalidUserID(t *testing.T) {
 }
 
 func TestRegisterFinishSessionExpired(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/register/finish?user_id=99999", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -725,7 +675,7 @@ func TestRegisterFinishSessionExpired(t *testing.T) {
 // --- LoginPage tests ---
 
 func TestLoginPage(t *testing.T) {
-	h, _, r := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -734,13 +684,13 @@ func TestLoginPage(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "LoginPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "login-button")
 }
 
 // --- LoginBegin tests ---
 
 func TestLoginBegin(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/login/begin", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -756,7 +706,7 @@ func TestLoginBegin(t *testing.T) {
 // --- LoginFinish tests ---
 
 func TestLoginFinishMissingSessionID(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/login/finish", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -769,7 +719,7 @@ func TestLoginFinishMissingSessionID(t *testing.T) {
 }
 
 func TestLoginFinishSessionExpired(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/login/finish?session_id=nonexistent", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -784,7 +734,7 @@ func TestLoginFinishSessionExpired(t *testing.T) {
 // --- Logout tests ---
 
 func TestLogout(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/logout", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -803,14 +753,12 @@ func TestLogout(t *testing.T) {
 func TestLogoutCustomRedirect(t *testing.T) {
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
 	h := testApp(t, testI18nBundle(t))
 	h.repo = repo
 	h.webauthn = waSvc
-	h.renderer = renderer
 	h.config = &Config{
 		LoginRedirect:  "/dashboard",
 		LogoutRedirect: "/goodbye",
@@ -830,7 +778,7 @@ func TestLogoutCustomRedirect(t *testing.T) {
 // --- CredentialsPage tests ---
 
 func TestCredentialsPage(t *testing.T) {
-	h, repo, r := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, err := repo.CreateUser(context.Background(), "alice")
 	require.NoError(t, err)
 
@@ -842,13 +790,13 @@ func TestCredentialsPage(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "CredentialsPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "credentials-title")
 }
 
 // --- DeleteCredential tests ---
 
 func TestDeleteCredentialInvalidID(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	router := chi.NewRouter()
@@ -865,7 +813,7 @@ func TestDeleteCredentialInvalidID(t *testing.T) {
 }
 
 func TestDeleteCredentialLastCredential(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 	cred := &Credential{
 		UserID:       user.ID,
@@ -890,7 +838,7 @@ func TestDeleteCredentialLastCredential(t *testing.T) {
 }
 
 func TestDeleteCredentialSuccess(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 	cred1 := &Credential{UserID: user.ID, CredentialID: []byte("c1"), PublicKey: []byte("k1"), Name: "P1"}
 	cred2 := &Credential{UserID: user.ID, CredentialID: []byte("c2"), PublicKey: []byte("k2"), Name: "P2"}
@@ -913,7 +861,7 @@ func TestDeleteCredentialSuccess(t *testing.T) {
 // --- RecoveryPage tests ---
 
 func TestRecoveryPage(t *testing.T) {
-	h, _, r := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -921,13 +869,14 @@ func TestRecoveryPage(t *testing.T) {
 	err := h.RecoveryPage(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "RecoveryPage", r.lastMethod)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "recovery-description")
 }
 
 // --- RecoveryLogin tests ---
 
 func TestRecoveryLoginMissingFields(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	tests := []struct {
 		name string
@@ -953,7 +902,7 @@ func TestRecoveryLoginMissingFields(t *testing.T) {
 }
 
 func TestRecoveryLoginUserNotFound(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	body := strings.NewReader(`{"username":"nonexistent","code":"abcd-efgh-ijkl"}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -968,7 +917,7 @@ func TestRecoveryLoginUserNotFound(t *testing.T) {
 }
 
 func TestRecoveryLoginInvalidCode(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -989,7 +938,7 @@ func TestRecoveryLoginInvalidCode(t *testing.T) {
 }
 
 func TestRecoveryLoginSuccess(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -1012,7 +961,7 @@ func TestRecoveryLoginSuccess(t *testing.T) {
 }
 
 func TestRecoveryLoginLastCodeTriggersRegenerate(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -1048,7 +997,7 @@ func TestRecoveryLoginLastCodeTriggersRegenerate(t *testing.T) {
 }
 
 func TestRecoveryLoginPenultimateCodeKeepsHappyPath(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -1078,7 +1027,7 @@ func TestRecoveryLoginPenultimateCodeKeepsHappyPath(t *testing.T) {
 }
 
 func TestRecoveryLoginLastCodePreservesSessionRedirect(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -1105,7 +1054,7 @@ func TestRecoveryLoginLastCodePreservesSessionRedirect(t *testing.T) {
 // --- RegenerateRecoveryCodes tests ---
 
 func TestRegenerateRecoveryCodes(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -1128,7 +1077,7 @@ func TestRegenerateRecoveryCodes(t *testing.T) {
 // --- RecoveryCodesPage tests ---
 
 func TestRecoveryCodesPageWithCodes(t *testing.T) {
-	h, _, r := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery-codes", nil)
 	req = session.Inject(req, map[string]any{
@@ -1136,6 +1085,7 @@ func TestRecoveryCodesPageWithCodes(t *testing.T) {
 		"recovery_codes": []string{"code1", "code2"},
 	})
 	ctx := WithUser(req.Context(), testUserWithID())
+	ctx = burrow.WithTemplateExecutor(ctx, rendererTestExecutor())
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 
@@ -1143,11 +1093,12 @@ func TestRecoveryCodesPageWithCodes(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "RecoveryCodesPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "recovery-codes-title")
+	assert.Contains(t, rec.Body.String(), "code1")
 }
 
 func TestRecoveryCodesPageWithoutCodes(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery-codes", nil)
 	req = requestWithSession(req, testUserWithID())
@@ -1163,7 +1114,7 @@ func TestRecoveryCodesPageWithoutCodes(t *testing.T) {
 // --- AcknowledgeRecoveryCodes tests ---
 
 func TestAcknowledgeRecoveryCodes(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery-codes/ack", nil)
 	req = session.Inject(req, map[string]any{
@@ -1182,7 +1133,7 @@ func TestAcknowledgeRecoveryCodes(t *testing.T) {
 }
 
 func TestAcknowledgeRecoveryCodesWithRedirect(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery-codes/ack", nil)
 	req = session.Inject(req, map[string]any{
@@ -1204,7 +1155,7 @@ func TestAcknowledgeRecoveryCodesWithRedirect(t *testing.T) {
 // --- Email verification tests ---
 
 func TestVerifyPendingPage(t *testing.T) {
-	h, _, r := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-pending", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -1212,11 +1163,12 @@ func TestVerifyPendingPage(t *testing.T) {
 	err := h.VerifyPendingPage(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "VerifyPendingPage", r.lastMethod)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "verify-pending-title")
 }
 
 func TestVerifyEmailMissingToken(t *testing.T) {
-	h, _, r := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-email", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -1224,11 +1176,12 @@ func TestVerifyEmailMissingToken(t *testing.T) {
 	err := h.VerifyEmail(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "VerifyEmailErrorPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "verify-error-title")
+	assert.Contains(t, rec.Body.String(), "verify-error-missing-token")
 }
 
 func TestVerifyEmailInvalidToken(t *testing.T) {
-	h, _, r := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-email?token=invalid", nil)
 	req = requestWithSession(req, nil)
 	rec := httptest.NewRecorder()
@@ -1236,11 +1189,12 @@ func TestVerifyEmailInvalidToken(t *testing.T) {
 	err := h.VerifyEmail(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "VerifyEmailErrorPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "verify-error-title")
+	assert.Contains(t, rec.Body.String(), "verify-error-invalid-token")
 }
 
 func TestVerifyEmailExpiredToken(t *testing.T) {
-	h, repo, r := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 	user, _ := repo.CreateUserWithEmail(context.Background(), "test@example.com")
 	tokenHash := HashToken("expiredtoken")
 	require.NoError(t, repo.CreateEmailVerificationToken(context.Background(), user.ID, tokenHash, time.Now().Add(-time.Hour)))
@@ -1252,11 +1206,12 @@ func TestVerifyEmailExpiredToken(t *testing.T) {
 	err := h.VerifyEmail(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "VerifyEmailErrorPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "verify-error-title")
+	assert.Contains(t, rec.Body.String(), "verify-error-token-expired")
 }
 
 func TestVerifyEmailSuccess(t *testing.T) {
-	h, repo, r := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 	user, _ := repo.CreateUserWithEmail(context.Background(), "test@example.com")
 	tokenHash := HashToken("validtoken")
 	require.NoError(t, repo.CreateEmailVerificationToken(context.Background(), user.ID, tokenHash, time.Now().Add(24*time.Hour)))
@@ -1268,7 +1223,7 @@ func TestVerifyEmailSuccess(t *testing.T) {
 	err := h.VerifyEmail(rec, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "VerifyEmailSuccessPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "verify-success-title")
 
 	// User should be marked as verified.
 	got, _ := repo.GetUserByID(context.Background(), user.ID)
@@ -1278,7 +1233,7 @@ func TestVerifyEmailSuccess(t *testing.T) {
 // --- ResendVerification tests ---
 
 func TestResendVerificationMissingEmail(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	body := strings.NewReader(`{"email":""}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/resend-verification", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -1292,7 +1247,7 @@ func TestResendVerificationMissingEmail(t *testing.T) {
 }
 
 func TestResendVerificationNonexistentEmail(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 	body := strings.NewReader(`{"email":"nobody@example.com"}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/resend-verification", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -1327,7 +1282,7 @@ func TestErrorJSONLogNilError(t *testing.T) {
 // --- ResendVerification additional paths ---
 
 func TestResendVerificationAlreadyVerified(t *testing.T) {
-	h, repo, _ := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 
 	user, err := repo.CreateUserWithEmail(context.Background(), "verified@example.com")
 	require.NoError(t, err)
@@ -1346,7 +1301,7 @@ func TestResendVerificationAlreadyVerified(t *testing.T) {
 }
 
 func TestResendVerificationSuccess(t *testing.T) {
-	h, repo, _ := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 
 	_, err := repo.CreateUserWithEmail(context.Background(), "test@example.com")
 	require.NoError(t, err)
@@ -1363,7 +1318,7 @@ func TestResendVerificationSuccess(t *testing.T) {
 }
 
 func TestResendVerificationInvalidJSON(t *testing.T) {
-	h, _, _ := setupTestAppEmailMode(t)
+	h, _ := setupTestAppEmailMode(t)
 
 	body := strings.NewReader(`{invalid}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/resend-verification", body)
@@ -1379,7 +1334,7 @@ func TestResendVerificationInvalidJSON(t *testing.T) {
 // --- RecoveryLogin with deactivated user ---
 
 func TestRecoveryLoginDeactivatedUser(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	ctx := context.Background()
 
 	user, err := repo.CreateUser(ctx, "inactive")
@@ -1401,7 +1356,7 @@ func TestRecoveryLoginDeactivatedUser(t *testing.T) {
 // --- RecoveryCodesPage with non-slice codes ---
 
 func TestRecoveryCodesPageInvalidType(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery-codes", nil)
 	req = session.Inject(req, map[string]any{
@@ -1422,7 +1377,7 @@ func TestRecoveryCodesPageInvalidType(t *testing.T) {
 // --- AcknowledgeRecoveryCodes redirect from session ---
 
 func TestAcknowledgeRecoveryCodesUsesSessionRedirect(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery-codes/ack", nil)
 	req = session.Inject(req, map[string]any{
@@ -1445,7 +1400,6 @@ func TestAcknowledgeRecoveryCodesUsesSessionRedirect(t *testing.T) {
 func TestRegisterBeginInviteOnlyEmailModeMismatch(t *testing.T) {
 	db := openTestDB(t)
 	repo := NewRepository[EmptyProfile](db)
-	renderer := &mockRenderer{}
 	waSvc, err := NewWebAuthnService(t.Context(), "Test App", "localhost", "http://localhost:8080")
 	require.NoError(t, err)
 
@@ -1454,7 +1408,6 @@ func TestRegisterBeginInviteOnlyEmailModeMismatch(t *testing.T) {
 	h.repo = repo
 	h.webauthn = waSvc
 	h.emailService = emailSvc
-	h.renderer = renderer
 	h.config = &Config{
 		LoginRedirect:       "/dashboard",
 		LogoutRedirect:      "/auth/login",
@@ -1492,7 +1445,7 @@ func TestRegisterBeginInviteOnlyEmailModeMismatch(t *testing.T) {
 // --- RegisterPageInviteOnlyExpiredToken ---
 
 func TestRegisterPageInviteOnlyExpiredToken(t *testing.T) {
-	h, repo, r := setupTestAppInviteOnly(t)
+	h, repo := setupTestAppInviteOnly(t)
 
 	// Create an expired invite.
 	invite := &Invite{
@@ -1508,7 +1461,8 @@ func TestRegisterPageInviteOnlyExpiredToken(t *testing.T) {
 
 	err := h.RegisterPage(rec, req)
 	require.NoError(t, err)
-	assert.Equal(t, "RegisterPage", r.lastMethod)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "register-username-label")
 }
 
 // --- UseEmailMode / IsInviteOnly with nil config ---
@@ -1555,7 +1509,7 @@ func TestFindStoredSignCountEmptySlice(t *testing.T) {
 // --- RecoveryLogin invalid JSON ---
 
 func TestRecoveryLoginInvalidJSON(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 	body := strings.NewReader(`{invalid}`)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -1571,7 +1525,7 @@ func TestRecoveryLoginInvalidJSON(t *testing.T) {
 // --- RecoveryCodesPage with empty codes slice ---
 
 func TestRecoveryCodesPageEmptyCodes(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery-codes", nil)
 	req = session.Inject(req, map[string]any{
@@ -1609,8 +1563,9 @@ func TestVerifyEmailDBErrorOnMarkVerified(t *testing.T) {
 
 	err = h.VerifyEmail(rec, req)
 	require.NoError(t, err)
-	// Should render the error page.
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	// Renders the error page (an HTML page, served with 200).
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "verify-error-title")
 }
 
 // --- VerifyEmail: DB error on GetUserByID after verification ---
@@ -1634,14 +1589,15 @@ func TestVerifyEmailDBErrorOnGetUserAfterVerify(t *testing.T) {
 
 	err = h.VerifyEmail(rec, req)
 	require.NoError(t, err)
-	// GetUserByID returns ErrNotFound, should render error page.
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	// GetUserByID returns ErrNotFound → renders the error page (200).
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "verify-error-title")
 }
 
 // --- ResendVerification: user with nil email ---
 
 func TestResendVerificationUserWithNilEmail(t *testing.T) {
-	h, repo, _ := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 
 	// Create a user via username mode (no email), then look up by email.
 	// Since GetUserByEmail would fail for a username-mode user, we need a user
@@ -1798,7 +1754,7 @@ func TestResendVerificationDBErrorOnTokenCreate(t *testing.T) {
 // --- RegenerateRecoveryCodes: first-time generation (no existing codes to delete) ---
 
 func TestRegenerateRecoveryCodesFirstTime(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "charlie")
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery-codes/regenerate", nil)
@@ -1814,7 +1770,7 @@ func TestRegenerateRecoveryCodesFirstTime(t *testing.T) {
 // --- RecoveryLogin with session redirect ---
 
 func TestRecoveryLoginUsesSessionRedirect(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "alice")
 
 	svc := &RecoveryService{BcryptCost: bcrypt.MinCost}
@@ -1839,7 +1795,7 @@ func TestRecoveryLoginUsesSessionRedirect(t *testing.T) {
 // --- CredentialsPage with credentials ---
 
 func TestCredentialsPageWithCredentials(t *testing.T) {
-	h, repo, r := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, err := repo.CreateUser(context.Background(), "dave")
 	require.NoError(t, err)
 
@@ -1853,13 +1809,13 @@ func TestCredentialsPageWithCredentials(t *testing.T) {
 	err = h.CredentialsPage(rec, req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "CredentialsPage", r.lastMethod)
+	assert.Contains(t, rec.Body.String(), "My Key")
 }
 
 // --- AcknowledgeRecoveryCodes: no session middleware ---
 
 func TestAcknowledgeRecoveryCodesNoSession(t *testing.T) {
-	h, _, _ := setupTestApp(t)
+	h, _ := setupTestApp(t)
 
 	// Request WITHOUT session.Inject — session.Delete will return errNoMiddleware.
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/recovery-codes/ack", nil)
@@ -1874,7 +1830,7 @@ func TestAcknowledgeRecoveryCodesNoSession(t *testing.T) {
 // --- RegenerateRecoveryCodes: no session middleware ---
 
 func TestRegenerateRecoveryCodesNoSession(t *testing.T) {
-	h, repo, _ := setupTestApp(t)
+	h, repo := setupTestApp(t)
 	user, _ := repo.CreateUser(context.Background(), "nosession")
 
 	// Request WITHOUT session.Inject — session.Set will fail.
@@ -1889,37 +1845,10 @@ func TestRegenerateRecoveryCodesNoSession(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "failed to store recovery codes")
 }
 
-// --- VerifyEmail: DB error after token found (GetEmailVerificationToken succeeds) ---
-
-func TestVerifyEmailGetUserByIDFailure(t *testing.T) {
-	// Test the path where MarkEmailVerified succeeds but GetUserByID fails.
-	// Create a user, create a token, then delete the user to orphan the token.
-	h, repo, _ := setupTestAppEmailModeClosable(t)
-	ctx := context.Background()
-
-	user, err := repo.CreateUserWithEmail(ctx, "orphan@example.com")
-	require.NoError(t, err)
-
-	tokenHash := HashToken("orphantoken")
-	require.NoError(t, repo.CreateEmailVerificationToken(ctx, user.ID, tokenHash, time.Now().Add(24*time.Hour)))
-
-	// Delete the user to orphan the token.
-	require.NoError(t, repo.DeleteUser(ctx, user.ID))
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-email?token=orphantoken", nil)
-	req = requestWithSession(req, nil)
-	rec := httptest.NewRecorder()
-
-	err = h.VerifyEmail(rec, req)
-	require.NoError(t, err)
-	// MarkEmailVerified updates 0 rows (no error), then GetUserByID returns ErrNotFound.
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
-
 // --- ResendVerification: full path with existing old tokens ---
 
 func TestResendVerificationDeletesOldTokens(t *testing.T) {
-	h, repo, _ := setupTestAppEmailMode(t)
+	h, repo := setupTestAppEmailMode(t)
 	ctx := context.Background()
 
 	user, err := repo.CreateUserWithEmail(ctx, "test@example.com")

--- a/contrib/auth/pages.go
+++ b/contrib/auth/pages.go
@@ -19,24 +19,17 @@ func DefaultAuthLayout() string {
 	return "auth/layout"
 }
 
-// DefaultRenderer returns the default Renderer that uses the built-in HTML
-// templates. Templates use burrow.RenderTemplate which reads layout from
-// context: if a layout is set, page content is wrapped in it; otherwise
-// bare content is rendered.
-func DefaultRenderer() Renderer {
-	return &defaultRenderer{}
-}
+// The functions below render auth's built-in pages. Hosts customise a page by
+// redefining its template (e.g. {{ define "auth/login" }}) — last-define-wins
+// at parse time — so there is no renderer abstraction to swap.
 
-// defaultRenderer implements Renderer using built-in HTML templates.
-type defaultRenderer struct{}
-
-func (d *defaultRenderer) LoginPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error {
+func loginPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error {
 	return renderCentered(w, r, i18n.T(r.Context(), "login-title"), "auth/login", map[string]any{
 		"LoginRedirect": loginRedirect,
 	})
 }
 
-func (d *defaultRenderer) RegisterPage(w http.ResponseWriter, r *http.Request, useEmail, inviteOnly bool, email, invite string) error {
+func registerPage(w http.ResponseWriter, r *http.Request, useEmail, inviteOnly bool, email, invite string) error {
 	return renderCard(w, r, i18n.T(r.Context(), "register-title"), "", "auth/register", map[string]any{
 		"UseEmail":   useEmail,
 		"InviteOnly": inviteOnly,
@@ -45,33 +38,33 @@ func (d *defaultRenderer) RegisterPage(w http.ResponseWriter, r *http.Request, u
 	})
 }
 
-func (d *defaultRenderer) CredentialsPage(w http.ResponseWriter, r *http.Request, creds []Credential) error {
+func credentialsPage(w http.ResponseWriter, r *http.Request, creds []Credential) error {
 	return renderCard(w, r, i18n.T(r.Context(), "credentials-title"), i18n.T(r.Context(), "credentials-title"), "auth/credentials", map[string]any{
 		"Creds": creds,
 	})
 }
 
-func (d *defaultRenderer) RecoveryPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error {
+func recoveryPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error {
 	return renderCard(w, r, i18n.T(r.Context(), "recovery-title"), "", "auth/recovery", map[string]any{
 		"LoginRedirect": loginRedirect,
 	})
 }
 
-func (d *defaultRenderer) RecoveryCodesPage(w http.ResponseWriter, r *http.Request, codes []string) error {
+func recoveryCodesPage(w http.ResponseWriter, r *http.Request, codes []string) error {
 	return renderCard(w, r, i18n.T(r.Context(), "recovery-codes-title"), i18n.T(r.Context(), "recovery-codes-title"), "auth/recovery_codes", map[string]any{
 		"Codes": codes,
 	})
 }
 
-func (d *defaultRenderer) VerifyPendingPage(w http.ResponseWriter, r *http.Request) error {
+func verifyPendingPage(w http.ResponseWriter, r *http.Request) error {
 	return renderCard(w, r, i18n.T(r.Context(), "verify-pending-title"), i18n.T(r.Context(), "verify-pending-title"), "auth/verify_pending", nil)
 }
 
-func (d *defaultRenderer) VerifyEmailSuccessPage(w http.ResponseWriter, r *http.Request) error {
+func verifyEmailSuccessPage(w http.ResponseWriter, r *http.Request) error {
 	return renderCard(w, r, i18n.T(r.Context(), "verify-success-title"), i18n.T(r.Context(), "verify-success-title"), "auth/verify_success", nil)
 }
 
-func (d *defaultRenderer) VerifyEmailErrorPage(w http.ResponseWriter, r *http.Request, errorCode string) error {
+func verifyEmailErrorPage(w http.ResponseWriter, r *http.Request, errorCode string) error {
 	return renderCard(w, r, i18n.T(r.Context(), "verify-error-title"), i18n.T(r.Context(), "verify-error-title"), "auth/verify_error", map[string]any{
 		"ErrorCode": errorCode,
 	})

--- a/contrib/auth/pages_test.go
+++ b/contrib/auth/pages_test.go
@@ -19,9 +19,6 @@ import (
 //go:embed templates/*.html
 var testRendererTemplateFS embed.FS
 
-// Compile-time interface assertion.
-var _ Renderer = (*defaultRenderer)(nil)
-
 // testBaseFuncMap returns the common template functions needed to parse auth templates in tests.
 func testBaseFuncMap() template.FuncMap {
 	return template.FuncMap{
@@ -77,12 +74,11 @@ func withRendererTestExecutor(req *http.Request) *http.Request {
 	return req.WithContext(ctx)
 }
 
-func TestDefaultRendererLoginPage(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderLoginPage(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -91,12 +87,11 @@ func TestDefaultRendererLoginPage(t *testing.T) {
 	assert.NotContains(t, body, "<article ", "login page should not have a card frame")
 }
 
-func TestDefaultRendererRegisterPage(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderRegisterPage(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/register", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.RegisterPage(rec, req, false, false, "", "")
+	err := registerPage(rec, req, false, false, "", "")
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -105,12 +100,11 @@ func TestDefaultRendererRegisterPage(t *testing.T) {
 	assert.Contains(t, body, "<article ", "register page should be wrapped in a card")
 }
 
-func TestDefaultRendererRegisterPageEmailMode(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderRegisterPageEmailMode(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/register", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.RegisterPage(rec, req, true, false, "", "")
+	err := registerPage(rec, req, true, false, "", "")
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -118,15 +112,14 @@ func TestDefaultRendererRegisterPageEmailMode(t *testing.T) {
 	assert.NotContains(t, rec.Body.String(), "register-username-label")
 }
 
-func TestDefaultRendererCredentialsPage(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderCredentialsPage(t *testing.T) {
 	cred := Credential{Name: "My Passkey"}
 	cred.ID = "cred-1"
 	creds := []Credential{cred}
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/credentials", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.CredentialsPage(rec, req, creds)
+	err := credentialsPage(rec, req, creds)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -135,12 +128,11 @@ func TestDefaultRendererCredentialsPage(t *testing.T) {
 	assert.Contains(t, body, "<article ", "credentials page should be wrapped in a card")
 }
 
-func TestDefaultRendererRecoveryPage(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderRecoveryPage(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.RecoveryPage(rec, req, "/dashboard")
+	err := recoveryPage(rec, req, "/dashboard")
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -150,13 +142,12 @@ func TestDefaultRendererRecoveryPage(t *testing.T) {
 	assert.Contains(t, body, "<article ", "recovery page should be wrapped in a card")
 }
 
-func TestDefaultRendererRecoveryCodesPage(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderRecoveryCodesPage(t *testing.T) {
 	codes := []string{"aaaa-bbbb-cccc", "dddd-eeee-ffff"}
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/recovery-codes", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.RecoveryCodesPage(rec, req, codes)
+	err := recoveryCodesPage(rec, req, codes)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -171,12 +162,11 @@ func TestDefaultRendererRecoveryCodesPage(t *testing.T) {
 		"recovery-codes ack form must not fall back to method=POST (dead code)")
 }
 
-func TestDefaultRendererVerifyPendingPage(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderVerifyPendingPage(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-pending", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.VerifyPendingPage(rec, req)
+	err := verifyPendingPage(rec, req)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -185,12 +175,11 @@ func TestDefaultRendererVerifyPendingPage(t *testing.T) {
 	assert.Contains(t, body, "<article ", "verify pending page should be wrapped in a card")
 }
 
-func TestDefaultRendererVerifyEmailSuccess(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderVerifyEmailSuccess(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-email", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.VerifyEmailSuccessPage(rec, req)
+	err := verifyEmailSuccessPage(rec, req)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -199,12 +188,11 @@ func TestDefaultRendererVerifyEmailSuccess(t *testing.T) {
 	assert.Contains(t, body, "<article ", "verify email success page should be wrapped in a card")
 }
 
-func TestDefaultRendererVerifyEmailError(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderVerifyEmailError(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/verify-email", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.VerifyEmailErrorPage(rec, req, "invalid_token")
+	err := verifyEmailErrorPage(rec, req, "invalid_token")
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -214,8 +202,7 @@ func TestDefaultRendererVerifyEmailError(t *testing.T) {
 	assert.Contains(t, body, "<article ", "verify email error page should be wrapped in a card")
 }
 
-func TestDefaultRendererLoginPageWithLogo(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderLoginPageWithLogo(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil)
 
 	logoExec := rendererTestExecutorWithLogo(`<span class="test-logo">My Brand</span>`)
@@ -224,7 +211,7 @@ func TestDefaultRendererLoginPageWithLogo(t *testing.T) {
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 
 	require.NoError(t, err)
 	body := rec.Body.String()
@@ -232,20 +219,18 @@ func TestDefaultRendererLoginPageWithLogo(t *testing.T) {
 	assert.Contains(t, body, "My Brand")
 }
 
-func TestDefaultRendererLoginPageWithoutLogo(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderLoginPageWithoutLogo(t *testing.T) {
 	req := withRendererTestExecutor(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil))
 	rec := httptest.NewRecorder()
 
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 
 	require.NoError(t, err)
 	body := rec.Body.String()
 	assert.NotContains(t, body, `class="auth-logo"`)
 }
 
-func TestDefaultRendererWithLayout(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderWithLayout(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil)
 
 	exec := func(_ context.Context, name string, data map[string]any) (template.HTML, error) {
@@ -261,7 +246,7 @@ func TestDefaultRendererWithLayout(t *testing.T) {
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 
 	require.NoError(t, err)
 	assert.Contains(t, rec.Body.String(), "<layout-wrapper>")
@@ -269,8 +254,7 @@ func TestDefaultRendererWithLayout(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "</layout-wrapper>")
 }
 
-func TestDefaultRendererIncludesCSRFToken(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderIncludesCSRFToken(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil)
 
 	funcMap := testBaseFuncMap()
@@ -291,7 +275,7 @@ func TestDefaultRendererIncludesCSRFToken(t *testing.T) {
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 
 	require.NoError(t, err)
 	body := rec.Body.String()
@@ -308,31 +292,28 @@ func TestDefaultAuthLayout(t *testing.T) {
 
 // --- renderCentered/renderCard without executor ---
 
-func TestDefaultRendererLoginPageWithoutExecutor(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderLoginPageWithoutExecutor(t *testing.T) {
 	// Request without template executor => falls back to burrow.RenderTemplate.
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil)
 	rec := httptest.NewRecorder()
 
 	// This will try to use burrow.RenderTemplate which may return an error
 	// if no template set is configured, but we're testing the code path.
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 	// Without a template executor, renderCentered falls through to burrow.RenderTemplate
 	// which needs a template set. We just want to confirm it doesn't panic.
 	_ = err
 }
 
-func TestDefaultRendererRegisterPageWithoutExecutor(t *testing.T) {
-	r := DefaultRenderer()
+func TestRenderRegisterPageWithoutExecutor(t *testing.T) {
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/register", nil)
 	rec := httptest.NewRecorder()
 
-	err := r.RegisterPage(rec, req, false, false, "", "")
+	err := registerPage(rec, req, false, false, "", "")
 	_ = err // May error without templates, but should not panic.
 }
 
 func TestRenderCenteredExecError(t *testing.T) {
-	r := DefaultRenderer()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/login", nil)
 
 	// Executor that always returns an error.
@@ -343,13 +324,12 @@ func TestRenderCenteredExecError(t *testing.T) {
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 
-	err := r.LoginPage(rec, req, "/dashboard")
+	err := loginPage(rec, req, "/dashboard")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "template exec error")
 }
 
 func TestRenderCardExecError(t *testing.T) {
-	r := DefaultRenderer()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/auth/register", nil)
 
 	// Executor that always returns an error.
@@ -360,7 +340,7 @@ func TestRenderCardExecError(t *testing.T) {
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
 
-	err := r.RegisterPage(rec, req, false, false, "", "")
+	err := registerPage(rec, req, false, false, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "template exec error")
 }

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -26,12 +26,11 @@ srv := burrow.NewServer(
 )
 ```
 
-The constructor uses built-in defaults for the renderer and auth layout. Use options to override with custom implementations:
+The constructor uses a built-in auth layout. Override it with an option, and restyle individual pages by redefining their templates (see [Page rendering](#page-rendering)):
 
 ```go
-// With custom renderer and layout.
+// With a custom auth layout shell.
 auth.New[auth.EmptyProfile](
-    auth.WithRenderer(myCustomRenderer),
     auth.WithAuthLayout("myapp/auth-layout"),
 )
 ```
@@ -366,57 +365,31 @@ In templates (via `HasRequestFuncMap`):
 {{ end }}
 ```
 
-## Renderer
+## Page rendering
 
-The auth app uses a `Renderer` interface to render all user-facing HTML pages. Each method corresponds to one page in the authentication flow.
+The auth app renders its pages (login, register, credentials, recovery codes, email verification) with the shipped `auth/*` templates — Tailwind v4 markup wrapped in either a centered layout (login) or a card layout (the rest). `auth.DefaultAuthLayout()` returns `"auth/layout"`, the navbar-less shell from [Auth Layout](#auth-layout), so auth pages render inside it by default. Pass `auth.WithAuthLayout("")` to inherit the host's `srv.SetLayout` instead, or `auth.WithAuthLayout("myapp/auth-layout")` to swap in your own shell.
 
-### Default Renderer
-
-By default, `auth.New[auth.EmptyProfile]()` uses a built-in renderer that calls `burrow.Render()` with the shipped `auth/*` templates. These templates use Tailwind v4 utility classes and are wrapped in either a centered layout (login) or a card layout (register, credentials, recovery codes, etc.). `auth.DefaultAuthLayout()` returns `"auth/layout"` — the shipped, navbar-less shell described in [Auth Layout](#auth-layout) — so auth pages render inside that shell by default. To make auth pages inherit the host's `srv.SetLayout` instead, pass `auth.WithAuthLayout("")`. To swap in a custom shell, pass `auth.WithAuthLayout("myapp/auth-layout")` and override the renderer via `auth.WithRenderer(...)` when you need a different look.
-
-For most applications, the default renderer works out of the box — you only need to override it if you want to fundamentally change how auth pages are rendered.
-
-### Custom Renderer
-
-To fully control the auth page markup, implement the `Renderer` interface and pass it via `auth.WithRenderer()`:
+To restyle a page, **redefine its template**. Ship the block in your own app's templates (contributed via `HasTemplates` — see [Templates](#default-templates)); burrow parses every app's templates into one set and last definition wins, so an app registered after `auth` overrides the built-in block:
 
 ```go
-auth.New[auth.EmptyProfile](
-    auth.WithRenderer(myRenderer),
-)
+{{ define "auth/login" }}
+  <!-- your markup; the page's data is unchanged (see the table below) -->
+{{ end }}
 ```
 
-```go
-type Renderer interface {
-    RegisterPage(w http.ResponseWriter, r *http.Request, useEmail, inviteOnly bool, email, invite string) error
-    LoginPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error
-    CredentialsPage(w http.ResponseWriter, r *http.Request, creds []Credential) error
-    RecoveryPage(w http.ResponseWriter, r *http.Request, loginRedirect string) error
-    RecoveryCodesPage(w http.ResponseWriter, r *http.Request, codes []string) error
-    VerifyPendingPage(w http.ResponseWriter, r *http.Request) error
-    VerifyEmailSuccessPage(w http.ResponseWriter, r *http.Request) error
-    VerifyEmailErrorPage(w http.ResponseWriter, r *http.Request, errorCode string) error
-}
-```
+Overrides are markup-only: the data each page receives is fixed (there is no longer a renderer to pass custom Go-side data). The page templates and their data:
 
-Each method writes a complete HTTP response. You can use `burrow.Render()` with your own template names, or write HTML directly — whatever fits your application.
+| Template | Data available |
+|----------|----------------|
+| `auth/login` | `.LoginRedirect` |
+| `auth/register` | `.UseEmail`, `.InviteOnly`, `.Email`, `.Invite` |
+| `auth/credentials` | `.Creds` (`[]Credential`) |
+| `auth/recovery` | `.LoginRedirect` |
+| `auth/recovery_codes` | `.Codes` (`[]string`) |
+| `auth/verify_pending` / `auth/verify_success` | — |
+| `auth/verify_error` | `.ErrorCode` |
 
-A minimal custom renderer might look like this:
-
-```go
-type myRenderer struct{}
-
-func (r *myRenderer) LoginPage(w http.ResponseWriter, req *http.Request, loginRedirect string) error {
-    return burrow.Render(w, req, http.StatusOK, "myapp/login", map[string]any{
-        "LoginRedirect": loginRedirect,
-    })
-}
-
-// ... implement the remaining methods
-```
-
-!!! tip
-    You don't need a custom renderer just to change styles. The default templates use Tailwind v4 utility classes and are wrapped in the [auth layout](#auth-layout), which you can override separately via `auth.WithAuthLayout()`.
+The `auth/layout`, `auth/card`, and `auth/centered` wrappers receive `.Content`, `.Title`, and (card only) `.CardTitle`. No renderer abstraction to implement — template redefinition is the override mechanism.
 
 ## Admin Integration
 

--- a/docs/tutorial/part5.md
+++ b/docs/tutorial/part5.md
@@ -121,7 +121,7 @@ Visit `/auth/register` to create an account (you'll need a browser that supports
 
 ## What You've Learnt
 
-- **`auth.New[auth.EmptyProfile]()`** — configures the auth app with built-in default renderer and layout
+- **`auth.New[auth.EmptyProfile]()`** — configures the auth app with the built-in auth layout and page templates
 - **`auth.RequireAuth()`** — middleware that redirects unauthenticated users to login
 - **`auth.CurrentUser[auth.EmptyProfile]()`** — retrieves the authenticated user from request context
 - **`HasDependencies`** — declares inter-app dependencies for automatic ordering


### PR DESCRIPTION
## Summary

Removes the `contrib/auth` `Renderer` interface in favor of the framework's existing customization mechanism — template redefinition (last-define-wins).

The `Renderer` interface let a host swap the whole page-rendering engine, but nothing in-repo used `WithRenderer`, and since `html/template` is the settled engine, restyling a page is already done by redefining its template block. The interface was redundant indirection — and it meant every new auth page was a forced breaking change for custom-renderer implementers (the friction that surfaced while adding the API-keys page).

- Deletes the `Renderer` interface, `DefaultRenderer`, the `WithRenderer` option, and the `App[P].renderer` field.
- The former renderer methods are now unexported package funcs (`loginPage`, `registerPage`, …) in `pages.go` (renamed from `default_renderer.go`); the 15 handler call sites invoke them directly. `renderCard`/`renderCentered` are kept.
- Customization is now template redefinition only; `WithAuthLayout` is unchanged.

**Breaking:** custom `Renderer` implementations must drop `auth.WithRenderer(...)` and move markup changes into template overrides. Documented in the CHANGELOG and the auth guide (with a new template→data field table so override authors know what each page receives).

## Test plan

- `go test ./...` — green. Auth tests migrated off the mock renderers to real template executors; one duplicate verify-email test removed.
- `golangci-lint run ./...` — clean.
- `mise run docs-build` — no issues.