### PR TITLE
docs(examples): note the notes app's JSON API and API keys

### DIFF
--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -31,6 +31,7 @@ A full-featured notes application with authentication, an admin panel, and HTMX-
 
 - **Multi-app architecture** — session, CSRF, auth, admin, jobs, messages, htmx, and humanize all wired together in `main.go`
 - **Repository pattern** with Den/SQLite — CRUD operations, offset-based pagination
+- **Declarative JSON API** — `/api/notes` built with the [`crud` package](../guide/crud-api.md): an owner-scoped resource with a write DTO, authenticated by API-key bearer tokens (managed at the self-service `/auth/api-keys` page) alongside the session-based HTML UI
 - **FTS5 full-text search** — migration with triggers, `SearchByUserID` repository method, HTMX search form
 - **Admin views** — hand-written admin handlers with search, pagination, and htmx actions
 - **Custom layout** — navbar with navigation items, icon helpers, theme switcher


### PR DESCRIPTION
## Summary

The notes example now has a JSON CRUD API (`/api/notes` via the `crud` package), API-key bearer auth, and a self-service `/auth/api-keys` page — but the **Examples & Tutorial** overview didn't mention it. Adds one bullet to the Notes section's "What you can learn from it" list, linking to the JSON CRUD APIs guide.

## Test plan

- `mise run docs-build` — no issues (new cross-link resolves).