### PR TITLE
fix(crud): make update PATCH-only with partial-merge semantics

### DIFF
--- a/crud/crud_test.go
+++ b/crud/crud_test.go
@@ -208,14 +208,36 @@ func TestUpdate(t *testing.T) {
 	db := newDB(t)
 	w := save(t, db, &widget{Name: "old", Price: 1})
 
-	for _, method := range []string{http.MethodPut, http.MethodPatch} {
-		rec := do(t, mount(crud.NewResource[widget](db)), method, "/widgets/"+w.ID, `{"name":"updated","price":2}`, nil)
-		assert.Equal(t, http.StatusOK, rec.Code, method)
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodPatch, "/widgets/"+w.ID, `{"name":"updated","price":2}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
 
-		got, err := den.FindByID[widget](t.Context(), db, w.ID)
-		require.NoError(t, err)
-		assert.Equal(t, "updated", got.Name, method)
-	}
+	got, err := den.FindByID[widget](t.Context(), db, w.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated", got.Name)
+	assert.Equal(t, 2, got.Price)
+}
+
+func TestUpdateIsPatchOnly(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "old"})
+
+	// PUT is not generated — update is PATCH (partial merge) only.
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodPut, "/widgets/"+w.ID, `{"name":"x"}`, nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestUpdatePartialMergePreservesOmittedFields(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "old", Price: 5})
+
+	// PATCH only the name; price is omitted and must be preserved.
+	rec := do(t, mount(crud.NewResource[widget](db)), http.MethodPatch, "/widgets/"+w.ID, `{"name":"new"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := den.FindByID[widget](t.Context(), db, w.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Name)
+	assert.Equal(t, 5, got.Price, "omitted field is preserved (partial merge)")
 }
 
 func TestUpdateWithDTO(t *testing.T) {
@@ -227,13 +249,43 @@ func TestUpdateWithDTO(t *testing.T) {
 		return nil
 	}))
 
-	rec := do(t, mount(rs), http.MethodPut, "/widgets/"+w.ID, `{"name":"renamed","owner_id":"hacker"}`, nil)
+	rec := do(t, mount(rs), http.MethodPatch, "/widgets/"+w.ID, `{"name":"renamed","owner_id":"hacker"}`, nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	got, err := den.FindByID[widget](t.Context(), db, w.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "renamed", got.Name)
 	assert.Equal(t, "alice", got.OwnerID, "the DTO can't touch server-owned fields")
+}
+
+// TestUpdateWithPointerDTOPartial shows the supported partial-update pattern:
+// a pointer-field DTO whose mapper only applies fields the client actually sent.
+func TestUpdateWithPointerDTOPartial(t *testing.T) {
+	db := newDB(t)
+	w := save(t, db, &widget{Name: "old", Price: 7})
+
+	type patchInput struct {
+		Name  *string `json:"name"`
+		Price *int    `json:"price"`
+	}
+	rs := crud.NewResource[widget](db, crud.WithUpdate(func(in patchInput, dst *widget, _ *http.Request) error {
+		if in.Name != nil {
+			dst.Name = *in.Name
+		}
+		if in.Price != nil {
+			dst.Price = *in.Price
+		}
+		return nil
+	}))
+
+	// PATCH only the name; price is absent → mapper leaves it alone.
+	rec := do(t, mount(rs), http.MethodPatch, "/widgets/"+w.ID, `{"name":"renamed"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, err := den.FindByID[widget](t.Context(), db, w.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+	assert.Equal(t, 7, got.Price, "pointer DTO leaves omitted fields untouched")
 }
 
 func TestDelete(t *testing.T) {

--- a/crud/options.go
+++ b/crud/options.go
@@ -34,6 +34,15 @@ func WithCreate[T, C any](fn func(C, *http.Request) (*T, error)) Option[T] {
 // WithUpdate sets a typed write model for update: the request body is bound
 // and validated into U, then fn applies it onto the loaded document. Without
 // it, the body is bound directly onto the loaded T.
+//
+// Update is a partial merge (the route is PATCH). Standard JSON decoding gives
+// fields absent from the body their Go zero value, so for true partial updates
+// make U's fields pointers and apply them conditionally:
+//
+//	crud.WithUpdate(func(in updatePost, p *Post, _ *http.Request) error {
+//	    if in.Title != nil { p.Title = *in.Title }
+//	    return nil
+//	})
 func WithUpdate[T, U any](fn func(U, *T, *http.Request) error) Option[T] {
 	return func(rs *Resource[T]) {
 		rs.applyUpdate = func(r *http.Request, dst *T) error {

--- a/crud/resource.go
+++ b/crud/resource.go
@@ -100,7 +100,11 @@ func (rs *Resource[T]) register(r chi.Router) {
 		r.Get("/{id}", burrow.Handle(rs.handleGet))
 	}
 	if rs.enabled[ActionUpdate] {
-		r.Put("/{id}", burrow.Handle(rs.handleUpdate))
+		// Update is a partial merge (PATCH): the request applies its provided
+		// fields onto the loaded record. PUT (full replace) is intentionally
+		// not generated — it can't reset omitted fields while preserving the
+		// server-owned ID for an arbitrary T. Write a custom action if you
+		// need replace semantics.
 		r.Patch("/{id}", burrow.Handle(rs.handleUpdate))
 	}
 	if rs.enabled[ActionDelete] {

--- a/docs/guide/crud-api.md
+++ b/docs/guide/crud-api.md
@@ -44,7 +44,7 @@ func (a *App) Routes(r chi.Router) {
 | `GET` | `/api/notes` | List (paginated) |
 | `POST` | `/api/notes` | Create → `201` |
 | `GET` | `/api/notes/{id}` | Get |
-| `PUT` / `PATCH` | `/api/notes/{id}` | Update |
+| `PATCH` | `/api/notes/{id}` | Update (partial merge) |
 | `DELETE` | `/api/notes/{id}` | Delete → `204` |
 
 Lists use offset [pagination](pagination.md#json-api) and return a
@@ -107,19 +107,28 @@ type createNote struct {
     Body  string `json:"body"`
 }
 
+// Update is a partial merge — pointer fields distinguish "sent" from "absent".
+type updateNote struct {
+    Title *string `json:"title"`
+    Body  *string `json:"body"`
+}
+
 crud.NewResource[Note](a.db,
     crud.WithCreate(func(in createNote, r *http.Request) (*Note, error) {
         u := auth.MustCurrentUser[Profile](r.Context())
         return &Note{AuthorID: u.ID, Title: in.Title, Body: in.Body}, nil
     }),
-    crud.WithUpdate(func(in createNote, n *Note, r *http.Request) error {
-        n.Title, n.Body = in.Title, in.Body
+    crud.WithUpdate(func(in updateNote, n *Note, r *http.Request) error {
+        if in.Title != nil { n.Title = *in.Title } // only fields the client sent
+        if in.Body != nil { n.Body = *in.Body }
         return nil
     }),
 )
 ```
 
 Without these, the body binds directly onto the document (the simple case).
+
+**Update is a partial merge** — the route is `PATCH` (there is no generated `PUT`). The request applies its provided fields onto the loaded record. With a write DTO, give the update model **pointer fields** and apply them conditionally (above) so an omitted field isn't reset to its zero value; the no-DTO path is already partial because JSON decodes onto the loaded document.
 
 ## Output shaping
 

--- a/example/notes/internal/notes/api.go
+++ b/example/notes/internal/notes/api.go
@@ -9,11 +9,19 @@ import (
 	"github.com/oliverandrich/den/where"
 )
 
-// noteInput is the API write model. It omits UserID on purpose — ownership
-// comes from the authenticated user, never the client (mass-assignment guard).
-type noteInput struct {
+// createNoteInput is the create write model. It omits UserID on purpose —
+// ownership comes from the authenticated user, never the client.
+type createNoteInput struct {
 	Title   string `json:"title" validate:"required"`
 	Content string `json:"content"`
+}
+
+// updateNoteInput is the update write model. Update is a partial merge (PATCH),
+// so its fields are pointers: only the ones the client actually sends are
+// applied, leaving the rest untouched.
+type updateNoteInput struct {
+	Title   *string `json:"title"`
+	Content *string `json:"content"`
 }
 
 // apiRoutes mounts the JSON CRUD API for notes under /api/notes. It is the
@@ -32,11 +40,17 @@ func (a *App) apiRoutes(r chi.Router) {
 				return []where.Condition{where.Field("user_id").Eq(currentUserID(req))}
 			}),
 			// WithCreate stamps the owner on new records from the auth context.
-			crud.WithCreate(func(in noteInput, req *http.Request) (*Note, error) {
+			crud.WithCreate(func(in createNoteInput, req *http.Request) (*Note, error) {
 				return &Note{UserID: currentUserID(req), Title: in.Title, Content: in.Content}, nil
 			}),
-			crud.WithUpdate(func(in noteInput, n *Note, _ *http.Request) error {
-				n.Title, n.Content = in.Title, in.Content
+			// WithUpdate applies only the fields the PATCH actually carried.
+			crud.WithUpdate(func(in updateNoteInput, n *Note, _ *http.Request) error {
+				if in.Title != nil {
+					n.Title = *in.Title
+				}
+				if in.Content != nil {
+					n.Content = *in.Content
+				}
 				return nil
 			}),
 		))

--- a/example/notes/internal/notes/api_test.go
+++ b/example/notes/internal/notes/api_test.go
@@ -70,13 +70,14 @@ func TestAPICRUDRoundTrip(t *testing.T) {
 	rec = apiDo(t, r, http.MethodGet, "/api/notes/"+created.ID, "")
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	// Update, then read it back to confirm the change landed.
-	rec = apiDo(t, r, http.MethodPut, "/api/notes/"+created.ID, `{"title":"Renamed","content":"x"}`)
+	// PATCH only the title; content is omitted and must survive the partial merge.
+	rec = apiDo(t, r, http.MethodPatch, "/api/notes/"+created.ID, `{"title":"Renamed"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
 	rec = apiDo(t, r, http.MethodGet, "/api/notes/"+created.ID, "")
 	var reloaded Note
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &reloaded))
 	assert.Equal(t, "Renamed", reloaded.Title)
+	assert.Equal(t, "hello", reloaded.Content, "PATCH left the omitted content untouched")
 
 	// Delete.
 	rec = apiDo(t, r, http.MethodDelete, "/api/notes/"+created.ID, "")


### PR DESCRIPTION
## Summary

Fixes the update semantics in the `crud` package surfaced in the DRF production-readiness review.

**Before:** the generated resource registered both `PUT` and `PATCH` on the same handler (indistinguishable), and the two write paths had opposite behavior — the no-DTO path merged (partial), while a `WithUpdate` DTO mapper set every field unconditionally, so a `PATCH` with a partial body silently **zeroed omitted fields**.

**After:** update is **`PATCH` only**, a partial merge:
- No-DTO path decodes JSON onto the loaded record — omitted fields are preserved (already partial).
- Write DTOs use **pointer fields** applied conditionally (documented in `WithUpdate` and the guide; the notes example now splits `createNoteInput` (value/required) from `updateNoteInput` (pointer/partial) as the exemplar).
- The misleading `PUT` route is gone. True full-replace `PUT` needs generic ID preservation and is intentionally deferred (parked as a draft).

## Test plan

- `go test ./...` — green, incl. new tests: `PUT → 405`, no-DTO partial merge preserves omitted fields, pointer-DTO partial update, and the notes API round-trip now asserts a `PATCH` leaves the omitted field untouched.
- `golangci-lint run ./...` clean; `mise run docs-build` no issues (guide endpoint table + partial-update note updated).

Part of the crud production-hardening epic; the remaining DRF-parity gaps (client filtering/ordering/search, cursor pagination, ETag concurrency, OpenAPI, richer permissions, relation expansion, full-replace PUT) are parked as draft beans.