### PR TITLE
fix(crud): WithPresenter disables ?expand + pre-release polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 - **`crud` OpenAPI 3.0 spec generation.** `crud.NewAPI(info)` collects resources — `api.Mount(r, path, res)` mounts and records in one call — and serves an OpenAPI 3.0 document via `api.SpecHandler()`: every endpoint with its parameters (pagination/filter/ordering/search/expand), request/response schemas reflected from your Go types (with `validate` tags mapped to constraints), and the error envelope. `BaseURL` becomes the spec's server so paths stay relative. Built on [kin-openapi](https://github.com/getkin/kin-openapi).
 - **contrib/auth: API-key (personal access token) bearer auth.** The automatic user-loading middleware now also resolves an `Authorization: Bearer <token>` header, so non-browser API clients authenticate through the existing gates (`RequireAuth`/`RequireStaff`/`RequireAdmin`) with no extra middleware — a bearer request populates the same context as a session cookie. Those gates now answer API clients (`Accept: application/json`) with a 401 instead of a login redirect. Tokens are `brw_`-prefixed, stored only as their SHA256 hash (plaintext shown once), and managed through the auth repository (`CreateAPIKey`/`ListAPIKeysByUser`/`DeleteAPIKey`). Bearer API routes must be declared CSRF-exempt via `csrf.ExemptPaths`.
 - **contrib/auth: self-service API-key page at `/auth/api-keys`.** Authenticated users list, create (plaintext shown once), and revoke their own keys. Link to it from your account UI; restyle it by redefining the `auth/api_keys` template.
+- **`pagination.CursorResult` + `PageResult.NextCursor`.** A `CursorResult(hasMore, nextCursor)` helper and a `next_cursor` JSON field for forward cursor pagination, mirroring `OffsetResult`/`page`; re-exported as `burrow.CursorResult`. The field is `omitempty`, so existing offset responses are byte-for-byte unchanged.
+
+### Changed
+
+- **Den bumped to v0.17.0.** It ships the FTS literal-by-default `Search`, full-replace `PreserveServerFields`, and link `Marshal`/`LinkFields`/selective `WithFetchLinks` that the new `crud` package builds on. The re-exported `den.*` alias surface is API-compatible — no downstream changes required.
+
+### Security
+
+- **Go toolchain pinned to 1.26.4.** Picks up the patched standard library for GO-2026-5037 (`crypto/x509`) and GO-2026-5039 (`net/textproto`). The required `test` CI check stays on `1.26`; the lint job's `govulncheck` runs on 1.26.4.
 
 ## 0.26.0 — 2026-05-31
 

--- a/contrib/auth/models.go
+++ b/contrib/auth/models.go
@@ -152,10 +152,10 @@ func TransportsFromWebAuthn(transports []protocol.AuthenticatorTransport) string
 // APIKey is a hashed API key (personal access token) used for bearer
 // authentication of non-browser API clients. Only the SHA256 hash of the
 // token is stored; the plaintext is shown to the user exactly once at
-// creation. A key inherits the role of its owning user — the
-// [App.RequireAPIKey] middleware loads that user into the request context
-// just like the session path, so [RequireStaff]/[RequireAdmin] compose on
-// top unchanged.
+// creation. A key inherits the role of its owning user — the auth app's
+// user-loading middleware resolves an `Authorization: Bearer <key>` header into
+// the same request context as a session cookie, so [RequireAuth]/[RequireStaff]/
+// [RequireAdmin] compose on top unchanged.
 type APIKey struct {
 	document.Base
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`

--- a/crud/expand.go
+++ b/crud/expand.go
@@ -18,9 +18,11 @@ import (
 // ignored, never an error.
 //
 // Expansion is read-only (get and list) and resolves one level deep. Hydration
-// is batched, so expanding a list is not an N+1. It does not combine with
-// [WithPresenter] — a presenter owns the output shape, so a hydrated link never
-// surfaces through it. Without this option ?expand is ignored.
+// is batched, so expanding a list is not an N+1. Both the document type and the
+// linked type must be registered with Den; a name that is not a den.Link field
+// is logged at registration, not an error. It is disabled when [WithPresenter]
+// is set — a presenter owns the output shape, so ?expand is ignored rather than
+// bypassing it. Without this option ?expand is ignored.
 func WithExpandable[T any](fields ...string) Option[T] {
 	return func(rs *Resource[T]) {
 		rs.expandable = make(map[string]bool, len(fields))
@@ -56,9 +58,11 @@ func (rs *Resource[T]) validateExpandable() {
 }
 
 // expandFields returns the allowlisted relation fields the request asked to
-// expand (?expand=a,b), or nil when expansion is off or none match.
+// expand (?expand=a,b), or nil when expansion is off or none match. A presenter
+// owns the output shape, so expansion is disabled when one is set — otherwise a
+// client's ?expand would bypass the presenter and leak the raw document.
 func (rs *Resource[T]) expandFields(params url.Values) []string {
-	if len(rs.expandable) == 0 {
+	if len(rs.expandable) == 0 || rs.present != nil {
 		return nil
 	}
 	var fields []string

--- a/crud/expand_test.go
+++ b/crud/expand_test.go
@@ -112,6 +112,28 @@ func TestExpandUnknownAllowlistFieldWarns(t *testing.T) {
 	assert.NotContains(t, out, "field=author", "a real link field does not warn")
 }
 
+func TestExpandIgnoredWhenPresenterSet(t *testing.T) {
+	db, post := newPostDB(t)
+	// A presenter and expansion together: the presenter owns the output, so
+	// ?expand must not bypass it and leak the raw document.
+	rs := crud.NewResource[expPost](db,
+		crud.WithExpandable[expPost]("author"),
+		crud.WithPresenter(func(p *expPost) any { return map[string]any{"title": p.Title} }),
+	)
+
+	got := getJSON(t, mountPosts(rs), "/posts/"+post.ID+"?expand=author")
+	assert.Equal(t, "Earthsea", got["title"])
+	assert.NotContains(t, got, "author", "presenter wins; no raw field leaks via ?expand")
+
+	var resp burrow.PageResponse[map[string]any]
+	rec := do(t, mountPosts(rs), http.MethodGet, "/posts?expand=author", "", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	decode(t, rec, &resp)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "Earthsea", resp.Items[0]["title"])
+	assert.NotContains(t, resp.Items[0], "author", "list presenter not bypassed by ?expand")
+}
+
 func TestExpandList(t *testing.T) {
 	db, _ := newPostDB(t)
 	rs := crud.NewResource[expPost](db, crud.WithExpandable[expPost]("author"))

--- a/crud/options.go
+++ b/crud/options.go
@@ -75,8 +75,8 @@ func WithSort[T any](field string, dir den.SortDirection) Option[T] {
 }
 
 // Only restricts the resource to the named actions ([ActionList], [ActionGet],
-// [ActionCreate], [ActionUpdate], [ActionDelete]). Mutually exclusive with
-// [Except] — the last one applied wins.
+// [ActionCreate], [ActionUpdate], [ActionReplace], [ActionDelete]). Mutually
+// exclusive with [Except] — the last one applied wins.
 func Only[T any](actions ...string) Option[T] {
 	return func(rs *Resource[T]) { rs.enabled = actionSet(actions) }
 }

--- a/docs/contrib/auth.md
+++ b/docs/contrib/auth.md
@@ -268,7 +268,7 @@ func (a *App) AdminRoutes(r chi.Router) {
 
 ### API Key Authentication
 
-Non-browser clients authenticate with an API key (personal access token) sent as `Authorization: Bearer <token>`. There is **no separate middleware** — the automatic user-loading middleware resolves a bearer token to its owning user just like a session cookie, so the standard gates work unchanged. Gate an API the same way you gate any route:
+Non-browser clients authenticate with an API key (personal access token) sent as `Authorization: Bearer <token>`. There is **no separate middleware** — the automatic user-loading middleware resolves a bearer token to its owning user just like a session cookie, so the standard gates work unchanged. This is how the [JSON CRUD APIs](../guide/crud-api.md) layer authenticates machine clients. Gate an API the same way you gate any route:
 
 ```go
 r.Route("/api", func(r chi.Router) {

--- a/docs/contrib/csrf.md
+++ b/docs/contrib/csrf.md
@@ -104,7 +104,7 @@ token := csrf.Token(r.Context())
 
 ## Exempting Webhook Paths
 
-Cross-origin webhook receivers — Webmention inbound, ActivityPub inbox, payment callbacks — accept POSTs from external services without a CSRF token by design. The csrf app honours a capability interface so the app that owns the route declares the exemption locally:
+Cross-origin webhook receivers — Webmention inbound, ActivityPub inbox, payment callbacks — accept POSTs from external services without a CSRF token by design. Bearer-authenticated [JSON CRUD APIs](../guide/crud-api.md) need the same exemption (they carry no cookie). The csrf app honours a capability interface so the app that owns the route declares the exemption locally:
 
 ```go
 package webmention

--- a/docs/guide/crud-api.md
+++ b/docs/guide/crud-api.md
@@ -17,6 +17,7 @@ import (
     "github.com/oliverandrich/burrow/contrib/auth"
     "github.com/oliverandrich/burrow/crud"
     "github.com/oliverandrich/den"
+    "github.com/urfave/cli/v3"
 )
 
 type App struct {
@@ -176,9 +177,11 @@ struct tag needed) — `?expand=author,tags` honors several, comma-separated, an
 anything not listed is ignored (never an error). A `[]den.Link[T]` field expands
 to an array of objects. It works on get and list (hydration is batched, so
 expanding a list is not an N+1), resolves one level deep (no `author.org`
-chaining), and composes with filtering, search, and pagination. It does **not**
-combine with `WithPresenter` (a presenter owns the output shape, so a hydrated
-link never surfaces through it).
+chaining), and composes with filtering, search, and pagination. Both the
+document type **and** the linked type must be registered with Den
+(`den.Register`); a misspelled allowlist field is logged at boot, not an error.
+It is **disabled** when `WithPresenter` is set — a presenter owns the output
+shape, so `?expand` is ignored rather than bypassing it.
 
 ## Filtering, ordering & search
 
@@ -328,8 +331,10 @@ Two caveats:
 - `WithSort(field, den.Asc|den.Desc)` — default list ordering (creation time
   descending when unset). `field` is the JSON field name, e.g. `"title"`.
 - `Only(crud.ActionList, crud.ActionGet)` / `Except(crud.ActionDelete)` — expose
-  a subset of the six actions. Disable a standard action and write your own
-  sibling route to fully replace it.
+  a subset of the six actions (`ActionList`, `ActionGet`, `ActionCreate`,
+  `ActionUpdate`, `ActionReplace`, `ActionDelete`). `Only` and `Except` are
+  mutually exclusive; if both are passed, the last one wins. Disable a standard
+  action and write your own sibling route to fully replace it.
 
 ## Authentication and CSRF
 
@@ -388,9 +393,11 @@ once on first request and cached.
 The spec covers every enabled action with its parameters (pagination, filter,
 ordering, search, expand), request bodies (the `WithCreate`/`WithUpdate` write
 models, or `T` when none), response schemas, and the error envelope. Schemas are
-reflected from your Go types, and `validate` tags map onto constraints:
-`required`, `min`/`max` (string length or numeric bounds), `email`/`url`/`uuid`
-(format), `oneof` (enum). `WithPresenter` hides the output schema — a presenter
+reflected from your Go types, and a documented subset of `validate` tags maps
+onto constraints: `required`, `min`/`max` (string length or numeric bounds),
+`email`/`url`/`uuid` (format), `oneof` (enum). Other validator rules (`gte`,
+`len`, cross-field, custom) have no faithful OpenAPI 3.0 equivalent and are
+omitted rather than approximated. `WithPresenter` hides the output schema — a presenter
 returns an arbitrary shape — so a resource using one documents a generic object
 for its responses.
 

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -124,6 +124,9 @@ This renders a `<nav>` with numbered page links, previous/next buttons, and elli
 
 ## JSON API
 
+The [JSON CRUD APIs](crud-api.md) layer wraps results in `PageResponse` for you
+(offset and cursor); reach for the helpers below when hand-writing endpoints.
+
 For JSON APIs, wrap results with `PageResponse`:
 
 ```go

--- a/docs/migration/v0.27.md
+++ b/docs/migration/v0.27.md
@@ -1,0 +1,64 @@
+# Migrating to v0.27
+
+v0.27 adds the [JSON CRUD APIs](../guide/crud-api.md) package and bumps the Den
+and Go toolchains. Most of it is additive — the one breaking change is the
+removal of `contrib/auth`'s `Renderer` interface. This guide covers the concrete
+upgrade steps from v0.26.
+
+For the full list of changes, see the [v0.27 changelog](../changelog.md).
+
+## Quick orientation
+
+| What you used | What changes | Section |
+|---|---|---|
+| `auth.WithRenderer(...)` | Removed — restyle via template overrides | [Auth Renderer](#auth-renderer-removed) |
+| (nothing) | New `crud` package for JSON APIs | [New: crud](#new-crud-package) |
+| Den v0.16.x | Bumped to v0.17.0 (API-compatible) | [Den 0.17](#den-0170) |
+| Go 1.26.x | Pinned to 1.26.4 (security) | [Go toolchain](#go-toolchain) |
+| JSON clients hitting auth gates | Now get `401`, not a login redirect | [JSON 401](#json-clients-get-401) |
+
+## Auth Renderer (removed)
+
+`contrib/auth`'s `Renderer` interface and the `auth.WithRenderer(...)` option are
+gone. Auth pages render through their named templates; customize a page by
+redefining its block (last-define-wins) instead of implementing a renderer:
+
+```go
+// Before
+auth.New(auth.WithRenderer(myRenderer))
+
+// After — delete the option; override the template block you wanted to change:
+// {{ define "auth/login" }} …your markup… {{ end }}
+```
+
+`WithAuthLayout` is unchanged.
+
+## New: crud package
+
+Optional and opt-in — nothing to migrate. `crud.NewResource[T](db, opts…)` turns
+a Den document type into JSON CRUD endpoints (filtering, search/FTS, offset and
+cursor pagination, optimistic concurrency, full-replace PUT, relation expansion,
+and OpenAPI 3.0). See the [guide](../guide/crud-api.md). Note: bearer-authenticated
+API routes must be declared CSRF-exempt via `csrf.ExemptPaths`, and the OpenAPI
+generator (`crud.NewAPI`) links in [kin-openapi](https://github.com/getkin/kin-openapi)
+— only if you import it.
+
+## Den 0.17.0
+
+Burrow now requires Den v0.17.0. `go get` pulls it transitively; the re-exported
+`den.*` surface burrow uses is API-compatible, so no code changes are required.
+Run `go mod tidy` after upgrading.
+
+## Go toolchain
+
+The toolchain is pinned to **1.26.4** (`.mise.toml`) for the patched standard
+library fixing GO-2026-5037 / GO-2026-5039. If you build burrow from source,
+`mise install` (or your own toolchain) should provide 1.26.4 or newer.
+
+## JSON clients get 401
+
+Auth gates (`RequireAuth`/`RequireStaff`/`RequireAdmin`) now answer requests
+sending `Accept: application/json` with `401 Unauthorized` instead of a `302`
+redirect to the login page. Browser requests are unaffected. If a JSON client
+relied on following the redirect, switch it to authenticate with an
+[API-key bearer token](../contrib/auth.md#api-key-authentication).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - Context Helpers: reference/context-helpers.md
       - CLI: reference/cli.md
   - Migration:
+      - "v0.27": migration/v0.27.md
       - "v0.25": migration/v0.25.md
       - "v0.24": migration/v0.24.md
       - "v0.23": migration/v0.23.md


### PR DESCRIPTION
## Summary

Pre-release polish driven by a multi-agent review of the unreleased crud work.

**Bug fix (the load-bearing change):** a resource configured with both `WithPresenter` and `WithExpandable` leaked the raw document on the **list** path — a `?expand=` request took the `den.Marshal` branch and bypassed the presenter, returning every field (incl. ids/timestamps/expanded relations) the presenter existed to hide. `expandFields` now returns nothing when a presenter is set, so the presenter always wins (matching how GET already behaved). Pinned by `TestExpandIgnoredWhenPresenterSet`.

**Docs gaps closed:** the relation-expansion registration requirement + presenter rule; `Only`/`Except` mutual-exclusivity and the full action-constant list (guide + `Only` godoc); the `validate`→constraint subset's omitted rules; the missing `urfave/cli/v3` import in the simple-case snippet; see-also cross-links from pagination/auth/csrf into the crud guide; and a dead `[App.RequireAPIKey]` godoc link in `contrib/auth`.

**Release prep:** the missing CHANGELOG entries — Den 0.17.0 (Changed), Go 1.26.4 security pin (Security), `pagination.CursorResult`/`PageResult.NextCursor` (Added) — and a new `docs/migration/v0.27.md` (Renderer removal, Den/Go bumps, the JSON-client 401 behavior, crud as a new opt-in package).

## Test plan

- `go test ./crud/ ./example/...` — new `TestExpandIgnoredWhenPresenterSet` covers the leak; the rest of the suite is unchanged.
- `mise run lint` — 0 issues. `mise run docs-build` — no issues (new cross-links + migration guide resolve).