### PR TITLE
fix(apidocs): hide Scalar AI agent button; record Scalar license

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -24,6 +24,13 @@ headers in every distributed form.
 - **Copyright:** Copyright (c) 2020, Big Sky Software LLC
 - **License:** BSD 2-Clause — <https://github.com/bigskysoftware/htmx/blob/master/LICENSE>
 
+### Scalar API Reference v1.58.0
+
+- **Files:** `contrib/apidocs/static/scalar.standalone.js`
+- **URL:** <https://github.com/scalar/scalar>
+- **Copyright:** Copyright (c) 2023 Scalar
+- **License:** MIT — <https://github.com/scalar/scalar/blob/main/LICENSE>
+
 ## Development Tools
 
 ### mise

--- a/contrib/apidocs/templates/apidocs.html
+++ b/contrib/apidocs/templates/apidocs.html
@@ -15,6 +15,7 @@
       Scalar.createApiReference('#app', {
         url: document.getElementById('app').dataset.specUrl,
         withDefaultFonts: false,
+        agent: { disabled: true },
       })
     </script>
   </body>

--- a/mise-tasks/licenses
+++ b/mise-tasks/licenses
@@ -39,6 +39,13 @@ headers in every distributed form.
 - **Copyright:** Copyright (c) 2020, Big Sky Software LLC
 - **License:** BSD 2-Clause — <https://github.com/bigskysoftware/htmx/blob/master/LICENSE>
 
+### Scalar API Reference v1.58.0
+
+- **Files:** `contrib/apidocs/static/scalar.standalone.js`
+- **URL:** <https://github.com/scalar/scalar>
+- **Copyright:** Copyright (c) 2023 Scalar
+- **License:** MIT — <https://github.com/scalar/scalar/blob/main/LICENSE>
+
 ## Development Tools
 
 ### mise


### PR DESCRIPTION
## Summary

Follow-up polish to the vendored Scalar API-docs contrib:

- **Hide the "Ask AI" button** — pass `agent: { disabled: true }` to `Scalar.createApiReference`, so the doc page has no AI agent UI.
- **Third-party licenses** — the vendored `scalar.standalone.js` (MIT, v1.58.0) was missing from `THIRD_PARTY_LICENSES.md`; added it to the embedded-assets section of the `mise-tasks/licenses` generator and regenerated.

## Test plan

- `go build ./...`, `go test ./contrib/apidocs/...`, `mise run docs-build` — green.
- Live render against `example/notes`: `/api/docs` serves the page with `agent: { disabled: true }`; the AI button is gone (the bundle gates it on `agent.disabled`).