### PR TITLE
ci: pin checkout to v6.0.3, match action version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         go-version: ['1.26']
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
@@ -41,11 +41,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           # govulncheck below needs the patched stdlib (GO-2026-5037/5039,
           # fixed in 1.26.4); the test job stays on '1.26' to keep its required
@@ -64,11 +64,11 @@ jobs:
   scaffold-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26'
           cache: false
@@ -84,7 +84,7 @@ jobs:
       actions: read
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -100,7 +100,7 @@ jobs:
     env:
       VERSION: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/cmd/burrow/templates/project/.github/workflows/ci.yml
+++ b/cmd/burrow/templates/project/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -46,7 +46,7 @@ jobs:
       actions: read
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -61,7 +61,7 @@ jobs:
       contents: write
       packages: write # ghcr.io push
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # goreleaser needs the full history to walk tags + build the changelog.
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Clears 8 open zizmor `ref-version-mismatch` code-scanning alerts.

`actions/checkout` was pinned to the **v6.0.2** SHA (`de0fac2e…`) while its `# v6` comment's moving tag now resolves to **v6.0.3** (`df4cb1c0…`) — so the pin and the label disagreed. Fixes:

- Repin `actions/checkout` to the **v6.0.3** SHA across both `.github/workflows/ci.yml` (5×) and the scaffold template `cmd/burrow/templates/project/.github/workflows/ci.yml` (3×).
- Switch `actions/checkout` and `actions/setup-go` to **exact-version** comments (`# v6.0.3`, `# v6.4.0`) instead of bare majors, so a future patch release can't make the pin drift from its comment again. This matches the exact-version style already used for zizmor/mise/docker pins.

## Test plan

- The `Audit workflows (zizmor)` CI job re-runs the same analysis that filed the alerts — green there confirms the mismatches are resolved.