### PR TITLE
fix(server): recover panics in long-lived background loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- **Background loops no longer crash the process on panic.** The auth orphaned-user/email-token sweep, the WebAuthn session sweep, the rate-limiter eviction sweep, the jobs poller, and the SIGHUP graceful-restart handler now recover per-iteration panics (logged with a stack trace) instead of letting the goroutine panic propagate unrecovered.
+
 ## 0.28.0 — 2026-06-04
 
 ### Added

--- a/contrib/auth/app.go
+++ b/contrib/auth/app.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/internal/bgloop"
 	"github.com/oliverandrich/den/document"
 
 	"github.com/oliverandrich/burrow/contrib/session"
@@ -338,16 +339,19 @@ func (a *App[P]) backgroundCleanup(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			purged, err := a.repo.PurgeOrphanedUsers(ctx, maxAge)
-			if err != nil {
-				slog.Error("failed to purge orphaned users", "error", err)
-			} else if purged > 0 {
-				slog.Info("purged orphaned users", "count", purged)
-			}
+			func() {
+				defer bgloop.Recover("auth.backgroundCleanup")
+				purged, err := a.repo.PurgeOrphanedUsers(ctx, maxAge)
+				if err != nil {
+					slog.Error("failed to purge orphaned users", "error", err)
+				} else if purged > 0 {
+					slog.Info("purged orphaned users", "count", purged)
+				}
 
-			if err := a.repo.DeleteExpiredEmailVerificationTokens(ctx); err != nil {
-				slog.Error("failed to delete expired email verification tokens", "error", err)
-			}
+				if err := a.repo.DeleteExpiredEmailVerificationTokens(ctx); err != nil {
+					slog.Error("failed to delete expired email verification tokens", "error", err)
+				}
+			}()
 		}
 	}
 }

--- a/contrib/auth/services.go
+++ b/contrib/auth/services.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+	"github.com/oliverandrich/burrow/internal/bgloop"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -296,14 +297,23 @@ func (s *webauthnService) cleanup(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.mu.Lock()
-			now := time.Now()
-			for key, entry := range s.store {
-				if now.After(entry.expiresAt) {
-					delete(s.store, key)
-				}
-			}
-			s.mu.Unlock()
+			func() {
+				defer bgloop.Recover("auth.webauthnSessionCleanup")
+				s.sweepExpiredSessions()
+			}()
+		}
+	}
+}
+
+// sweepExpiredSessions removes all expired entries. The deferred unlock
+// guarantees the mutex is released even if iteration panics.
+func (s *webauthnService) sweepExpiredSessions() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for key, entry := range s.store {
+		if now.After(entry.expiresAt) {
+			delete(s.store, key)
 		}
 	}
 }

--- a/contrib/jobs/worker.go
+++ b/contrib/jobs/worker.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/internal/bgloop"
 	"github.com/oliverandrich/den"
 )
 
@@ -93,9 +94,15 @@ func (w *Worker) poll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			w.claimAndDispatch(ctx)
+			func() {
+				defer bgloop.Recover("jobs.poll")
+				w.claimAndDispatch(ctx)
+			}()
 		case <-maintenanceTicker.C:
-			w.maintenance(ctx)
+			func() {
+				defer bgloop.Recover("jobs.maintenance")
+				w.maintenance(ctx)
+			}()
 		}
 	}
 }

--- a/contrib/ratelimit/limiter.go
+++ b/contrib/ratelimit/limiter.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/oliverandrich/burrow/internal/bgloop"
 	"golang.org/x/time/rate"
 )
 
@@ -100,7 +101,10 @@ func (l *Limiter) cleanup() {
 		case <-l.done:
 			return
 		case <-ticker.C:
-			l.sweep()
+			func() {
+				defer bgloop.Recover("ratelimit.cleanup")
+				l.sweep()
+			}()
 		}
 	}
 }

--- a/internal/bgloop/bgloop.go
+++ b/internal/bgloop/bgloop.go
@@ -1,0 +1,39 @@
+// Package bgloop provides panic recovery for long-lived background goroutines.
+//
+// An unrecovered panic in any goroutine crashes the whole Go process, not just
+// that goroutine. Long-lived background loops (ticker-driven cleanup, queue
+// pollers) must therefore guard each iteration so a transient panic is logged
+// and the loop survives instead of taking the server down.
+//
+// Use Recover deferred inside the body of a loop iteration:
+//
+//	for {
+//		select {
+//		case <-ctx.Done():
+//			return
+//		case <-ticker.C:
+//			func() {
+//				defer bgloop.Recover("auth.backgroundCleanup")
+//				doWork(ctx)
+//			}()
+//		}
+//	}
+package bgloop
+
+import (
+	"log/slog"
+	"runtime"
+)
+
+// Recover recovers a panic in a background loop iteration, logging it with a
+// stack trace under the given loop name. It is a no-op when there is no panic.
+// Call it deferred at the top of the loop-iteration body.
+func Recover(name string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	stack := make([]byte, 4096)
+	n := runtime.Stack(stack, false)
+	slog.Error("panic recovered in background loop", "loop", name, "panic", r, "stack", string(stack[:n]))
+}

--- a/internal/bgloop/bgloop_test.go
+++ b/internal/bgloop/bgloop_test.go
@@ -1,0 +1,65 @@
+package bgloop
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// useLogger swaps the default slog logger for one writing into buf and
+// restores it after the test.
+func useLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func TestRecover_SwallowsPanicAndLogs(t *testing.T) {
+	buf := useLogger(t)
+
+	require.NotPanics(t, func() {
+		defer Recover("test.loop")
+		panic("boom")
+	})
+
+	out := buf.String()
+	assert.Contains(t, out, "background loop")
+	assert.Contains(t, out, "test.loop")
+	assert.Contains(t, out, "boom")
+	assert.Contains(t, out, "bgloop_test.go", "stack trace should be logged")
+}
+
+func TestRecover_NoPanicNoLog(t *testing.T) {
+	buf := useLogger(t)
+
+	require.NotPanics(t, func() {
+		defer Recover("test.loop")
+	})
+
+	assert.Empty(t, buf.String(), "no panic must not log anything")
+}
+
+// TestRecover_LoopSurvives pins the intended call-site pattern: a panic in one
+// iteration is contained, and subsequent iterations keep running.
+func TestRecover_LoopSurvives(t *testing.T) {
+	_ = useLogger(t)
+
+	iterations := 0
+	for i := range 3 {
+		func() {
+			defer Recover("test.loop")
+			iterations++
+			if i == 0 {
+				panic("first iteration explodes")
+			}
+		}()
+	}
+
+	assert.Equal(t, 3, iterations, "loop must continue after a panicking iteration")
+}

--- a/server/server_listen.go
+++ b/server/server_listen.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cloudflare/tableflip"
 	burrowapp "github.com/oliverandrich/burrow/app"
+	"github.com/oliverandrich/burrow/internal/bgloop"
 	"github.com/oliverandrich/burrow/registry"
 )
 
@@ -59,9 +60,12 @@ func startServerTableflip(
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, syscall.SIGHUP)
 		for range sig {
-			if err := upg.Upgrade(); err != nil {
-				slog.Error("upgrade failed", "error", err)
-			}
+			func() {
+				defer bgloop.Recover("server.sighupUpgrade")
+				if err := upg.Upgrade(); err != nil {
+					slog.Error("upgrade failed", "error", err)
+				}
+			}()
 		}
 	}()
 


### PR DESCRIPTION
## Summary

An unrecovered panic in any Go goroutine takes down the whole process, not just that goroutine. Several of Burrow's long-lived background goroutines ran without any recovery:

- `auth` orphaned-user / email-token cleanup (`contrib/auth/app.go`)
- WebAuthn session cleanup (`contrib/auth/services.go`)
- rate-limiter eviction sweep (`contrib/ratelimit/limiter.go`)
- jobs poller + maintenance (`contrib/jobs/worker.go`) — only the *handler* was guarded (`safeCall`), the poller itself was not
- SIGHUP graceful-restart loop (`server/server_listen.go`)

This adds a small internal helper `internal/bgloop.Recover(name)` (deferred; logs the panic with a stack trace via `slog`, no-op on the normal path) and wires it per-iteration into each loop, so a transient panic is logged and the loop survives the next tick instead of crashing the server.

The WebAuthn sweep was extracted into `sweepExpiredSessions()` with a deferred unlock so the mutex can't leak if iteration panics.

`bgloop` is intentionally internal — a public, user-facing observable-goroutine helper remains a parked design question.

## Test plan

- New `internal/bgloop` tests: panic is swallowed + logged with stack; no-panic path logs nothing; a panicking iteration does not stop the loop.
- `go build ./...`, `go test ./...` (all packages green), `golangci-lint run ./...` (0 issues).