### PR TITLE
feat(jobs): gate /healthz/ready on worker liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ## Unreleased
 
+### Added
+
+- **contrib/jobs reports worker liveness through `/healthz/ready`.** The jobs app now implements `ReadinessChecker`, returning 503 with a `jobs` entry when the poller stalls so orchestrators stop routing to an instance that can no longer drain its queue.
+
 ### Fixed
 
 - **Background loops no longer crash the process on panic.** The auth orphaned-user/email-token sweep, the WebAuthn session sweep, the rate-limiter eviction sweep, the jobs poller, and the SIGHUP graceful-restart handler now recover per-iteration panics (logged with a stack trace) instead of letting the goroutine panic propagate unrecovered.

--- a/contrib/jobs/readiness.go
+++ b/contrib/jobs/readiness.go
@@ -1,0 +1,54 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// readinessPollMultiplier sets how many poll intervals of silence are
+	// tolerated before the poller is considered stalled.
+	readinessPollMultiplier = 10
+	// readinessMinThreshold floors the staleness window so a sub-second poll
+	// interval doesn't produce a hair-trigger readiness check.
+	readinessMinThreshold = 30 * time.Second
+)
+
+// readinessThreshold returns how long the poller may be silent before it is
+// considered stalled: readinessPollMultiplier × the poll interval, floored at
+// readinessMinThreshold.
+func readinessThreshold(pollInterval time.Duration) time.Duration {
+	t := readinessPollMultiplier * pollInterval
+	if t < readinessMinThreshold {
+		return readinessMinThreshold
+	}
+	return t
+}
+
+// pollStale reports whether the last poll is older than threshold relative to now.
+func pollStale(lastPoll, now time.Time, threshold time.Duration) bool {
+	return now.Sub(lastPoll) > threshold
+}
+
+// ReadinessCheck reports the jobs worker as unready when the poller has not
+// ticked within the staleness threshold, so a stalled or dead worker turns
+// /healthz/ready into 503. It implements burrow.ReadinessChecker.
+//
+// This is a liveness check on the poll loop, not a correctness check on the
+// work: a poller that ticks but whose Claim fails every cycle (e.g. a lost DB
+// connection) keeps lastPollAt fresh and stays ready. Those claim failures are
+// logged in claimAndDispatch; alert on that log separately if you need it.
+func (a *App) ReadinessCheck(_ context.Context) error {
+	if a.worker == nil {
+		return errors.New("jobs worker not started")
+	}
+	stats := a.worker.Stats()
+	threshold := readinessThreshold(a.workerCfg.PollInterval)
+	if pollStale(stats.LastPollAt, time.Now(), threshold) {
+		return fmt.Errorf("jobs poller stalled: last poll %s ago (threshold %s)",
+			time.Since(stats.LastPollAt).Round(time.Second), threshold)
+	}
+	return nil
+}

--- a/contrib/jobs/readiness_test.go
+++ b/contrib/jobs/readiness_test.go
@@ -1,0 +1,132 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oliverandrich/burrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion: the jobs app reports worker liveness via readiness.
+var _ burrow.ReadinessChecker = (*App)(nil)
+
+func TestPollStale(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	const threshold = 30 * time.Second
+
+	tests := []struct {
+		name    string
+		lastAgo time.Duration
+		want    bool
+	}{
+		{"fresh", time.Second, false},
+		{"just under threshold", 29 * time.Second, false},
+		{"exactly at threshold", 30 * time.Second, false},
+		{"just over threshold", 31 * time.Second, true},
+		{"long stalled", 5 * time.Minute, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pollStale(now.Add(-tc.lastAgo), now, threshold))
+		})
+	}
+}
+
+func TestReadinessThreshold(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval time.Duration
+		want     time.Duration
+	}{
+		{"sub-second floored to 30s", time.Second, 30 * time.Second},
+		{"default 1s floored to 30s", time.Second, 30 * time.Second},
+		{"3s floored to 30s", 3 * time.Second, 30 * time.Second},
+		{"10s scales to 100s", 10 * time.Second, 100 * time.Second},
+		{"zero floored to 30s", 0, 30 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, readinessThreshold(tc.interval))
+		})
+	}
+}
+
+func TestWorker_Stats(t *testing.T) {
+	db := testDB(t)
+	repo := NewRepository(db)
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	handlers := map[string]burrow.JobHandlerFunc{
+		"block": func(_ context.Context, _ []byte) error {
+			started <- struct{}{}
+			<-release
+			return nil
+		},
+	}
+
+	cfg := testWorkerConfig()
+	cfg.NumWorkers = 3
+	w := NewWorker(repo, handlers, cfg, nil)
+
+	// Before Start: not running, nothing in flight.
+	pre := w.Stats()
+	assert.False(t, pre.Running)
+	assert.Equal(t, 3, pre.NumWorkers)
+	assert.Equal(t, 0, pre.InFlight)
+	assert.NotEmpty(t, pre.WorkerID)
+
+	_, err := repo.Enqueue(context.Background(), "block", `{}`, 3, 0, time.Now())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go w.Start(ctx)
+
+	// While the handler blocks: running, one job in flight, poll timestamp advancing.
+	<-started
+	require.Eventually(t, func() bool {
+		s := w.Stats()
+		return s.Running && s.InFlight == 1 && time.Since(s.LastPollAt) < time.Second
+	}, 2*time.Second, 10*time.Millisecond)
+
+	close(release)
+	require.Eventually(t, func() bool { return w.Stats().InFlight == 0 }, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-w.Done()
+	assert.False(t, w.Stats().Running, "worker reports stopped after Done")
+}
+
+func TestApp_ReadinessCheck_NilWorker(t *testing.T) {
+	app := New()
+	err := app.ReadinessCheck(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not started")
+}
+
+func TestApp_ReadinessCheck_FreshPoll(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+	app.workerCfg = DefaultWorkerConfig()
+	app.worker = NewWorker(app.repo, app.handlers, app.workerCfg, nil)
+	app.worker.lastPollAt.Store(time.Now().UnixNano())
+
+	require.NoError(t, app.ReadinessCheck(t.Context()))
+}
+
+func TestApp_ReadinessCheck_StalePoll(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+	app.workerCfg = DefaultWorkerConfig()
+	app.worker = NewWorker(app.repo, app.handlers, app.workerCfg, nil)
+	app.worker.lastPollAt.Store(time.Now().Add(-5 * time.Minute).UnixNano())
+
+	err := app.ReadinessCheck(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stalled")
+}

--- a/contrib/jobs/worker.go
+++ b/contrib/jobs/worker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oliverandrich/burrow"
@@ -44,6 +45,32 @@ type Worker struct { //nolint:govet // fieldalignment: readability over optimiza
 	jobs         chan *Job
 	wg           sync.WaitGroup
 	done         chan struct{}
+
+	// Liveness instrumentation (read via Stats).
+	lastPollAt atomic.Int64 // UnixNano of the most recent poll tick
+	inFlight   atomic.Int64 // jobs currently being processed
+	running    atomic.Bool  // true between Start and worker drain
+}
+
+// WorkerStats is a snapshot of the worker pool's runtime state.
+type WorkerStats struct {
+	WorkerID   string
+	LastPollAt time.Time
+	NumWorkers int
+	InFlight   int
+	Running    bool
+}
+
+// Stats returns a snapshot of the worker pool's runtime state for readiness
+// checks and the admin status panel.
+func (w *Worker) Stats() WorkerStats {
+	return WorkerStats{
+		WorkerID:   w.id,
+		LastPollAt: time.Unix(0, w.lastPollAt.Load()),
+		NumWorkers: w.config.NumWorkers,
+		InFlight:   int(w.inFlight.Load()),
+		Running:    w.running.Load(),
+	}
 }
 
 // NewWorker creates a new Worker. The exec parameter may be nil when
@@ -63,6 +90,11 @@ func NewWorker(repo *Repository, handlers map[string]burrow.JobHandlerFunc, conf
 // Start runs the poller and workers. It blocks until ctx is cancelled
 // and all in-flight jobs have finished.
 func (w *Worker) Start(ctx context.Context) {
+	w.running.Store(true)
+	// Stamp a baseline so readiness passes from the moment the poller starts,
+	// before the first tick fires.
+	w.lastPollAt.Store(time.Now().UnixNano())
+
 	// Start worker goroutines.
 	for range w.config.NumWorkers {
 		w.wg.Go(w.work)
@@ -74,6 +106,7 @@ func (w *Worker) Start(ctx context.Context) {
 	// Poller stopped — close the channel so workers drain and exit.
 	close(w.jobs)
 	w.wg.Wait()
+	w.running.Store(false)
 	close(w.done)
 }
 
@@ -94,6 +127,9 @@ func (w *Worker) poll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Stamp before dispatching: if claimAndDispatch blocks (e.g. all
+			// workers stuck), the loop can't re-stamp and readiness goes stale.
+			w.lastPollAt.Store(time.Now().UnixNano())
 			func() {
 				defer bgloop.Recover("jobs.poll")
 				w.claimAndDispatch(ctx)
@@ -143,6 +179,9 @@ func (w *Worker) work() {
 }
 
 func (w *Worker) processJob(job *Job) {
+	w.inFlight.Add(1)
+	defer w.inFlight.Add(-1)
+
 	// Increment attempts and stamp ownership — persisted atomically via Complete or Fail.
 	job.Attempts++
 	job.WorkerID = w.id


### PR DESCRIPTION
## Summary

The jobs worker pool had no liveness signal: a stalled or dead poller left `/healthz/ready` green, so an orchestrator kept routing to an instance that could no longer drain its queue.

This instruments the worker and wires it into readiness:

- `Worker` now tracks `lastPollAt` (stamped each poll tick + a baseline at `Start`), `inFlight` (jobs currently processing), and `running` (across `Start`→drain), exposed via `Worker.Stats() WorkerStats`.
- The jobs `App` implements `burrow.ReadinessChecker`: when the poller hasn't ticked within `max(10× poll interval, 30s)`, `/healthz/ready` returns 503 with a `jobs` entry.
- `lastPollAt` is stamped *before* `claimAndDispatch`, so a wedged worker pool (dispatch blocked) also trips the check, not just a dead loop.

This is a liveness check on the poll loop, not a correctness check on the work — a poller that ticks but whose `Claim` fails every cycle stays ready (those failures are logged); the limitation is documented in `readiness.go`.

`Worker.Stats()` also feeds the upcoming admin worker-status panel.

## Test plan

- Pure-function table tests for `pollStale` (boundary at threshold) and `readinessThreshold` (sub-second floored to 30s, scaling above).
- `Worker.Stats()` instrumentation test under a blocking handler: running/in-flight/last-poll transitions, and stopped-after-`Done`.
- `App.ReadinessCheck`: nil worker → error, fresh poll → ok, stale poll → error.
- `go test ./...` green incl. `-race` on contrib/jobs; `golangci-lint` 0 issues.