### PR TITLE
feat(jobs): add worker-status panel to admin jobs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 ### Added
 
 - **contrib/jobs reports worker liveness through `/healthz/ready`.** The jobs app now implements `ReadinessChecker`, returning 503 with a `jobs` entry when the poller stalls so orchestrators stop routing to an instance that can no longer drain its queue.
+- **contrib/jobs admin: worker-status panel.** The `/admin/jobs` page now shows a card with the worker pool's state (running / stopped / stalled), worker count, in-flight jobs, last poll time, and per-status job counts.
 
 ### Fixed
 

--- a/contrib/jobs/admin_handlers.go
+++ b/contrib/jobs/admin_handlers.go
@@ -19,11 +19,17 @@ func (a *App) adminListJobs(w http.ResponseWriter, r *http.Request) error {
 		return burrow.NewHTTPError(http.StatusInternalServerError, "failed to list jobs")
 	}
 
+	workerStatus, err := a.workerStatus(r.Context())
+	if err != nil {
+		return burrow.NewHTTPError(http.StatusInternalServerError, "failed to load worker status")
+	}
+
 	return burrow.Render(w, r, http.StatusOK, "jobs/admin_list", map[string]any{
 		"Jobs":     jobs,
 		"Page":     page,
 		"Status":   string(status),
 		"RawQuery": r.URL.RawQuery,
+		"Worker":   workerStatus,
 	})
 }
 

--- a/contrib/jobs/admin_status.go
+++ b/contrib/jobs/admin_status.go
@@ -1,0 +1,55 @@
+package jobs
+
+import (
+	"context"
+	"time"
+)
+
+// statusCount pairs a job status with its current count for the status card.
+type statusCount struct {
+	Status JobStatus
+	Count  int
+}
+
+// workerStatusView is the worker-pool health summary rendered above the admin
+// job list: pool meta from the running worker plus per-status job counts.
+type workerStatusView struct {
+	LastPollAt time.Time
+	Counts     []statusCount
+	Workers    int
+	InFlight   int
+	Started    bool // a worker has been created (false before Start / in tests)
+	Running    bool // the worker pool is live (false once drained)
+	Stale      bool // the poller has not ticked within the readiness threshold
+}
+
+// workerStatus assembles the worker-status panel data: per-status job counts
+// (always all five statuses) plus live pool metrics when a worker exists.
+func (a *App) workerStatus(ctx context.Context) (workerStatusView, error) {
+	counts, err := a.repo.CountByStatus(ctx)
+	if err != nil {
+		return workerStatusView{}, err
+	}
+
+	view := workerStatusView{
+		Counts: []statusCount{
+			{StatusPending, counts[StatusPending]},
+			{StatusRunning, counts[StatusRunning]},
+			{StatusFailed, counts[StatusFailed]},
+			{StatusDead, counts[StatusDead]},
+			{StatusCompleted, counts[StatusCompleted]},
+		},
+	}
+
+	if a.worker != nil {
+		s := a.worker.Stats()
+		view.Started = true
+		view.Running = s.Running
+		view.Workers = s.NumWorkers
+		view.InFlight = s.InFlight
+		view.LastPollAt = s.LastPollAt
+		view.Stale = pollStale(s.LastPollAt, time.Now(), readinessThreshold(a.workerCfg.PollInterval))
+	}
+
+	return view, nil
+}

--- a/contrib/jobs/admin_status_test.go
+++ b/contrib/jobs/admin_status_test.go
@@ -1,0 +1,190 @@
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/oliverandrich/burrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderAdminList parses the real jobs templates (admin_list provides the
+// worker-status card, admin_detail provides the status_badge it calls) and
+// executes the card with the given view. It pins that every field and method
+// the card references actually resolves — the auth gate hides this path from
+// the live-server smoke test.
+func renderAdminList(t *testing.T, view workerStatusView) string {
+	t.Helper()
+	app := &App{}
+	funcs := app.FuncMap() // real prettyJSON/jobStatus/string used across the jobs templates
+	funcs["t"] = func(s string) string { return s }
+	funcs["dict"] = func(...any) map[string]any { return map[string]any{} }
+	tmpl, err := template.New("jobs").Funcs(funcs).ParseFS(app.TemplateFS(), "*.html")
+	require.NoError(t, err)
+	// admin/pagination lives in the admin contrib; stub it so html/template's
+	// escaping pass resolves the (unreached, empty-list) reference.
+	_, err = tmpl.Parse(`{{ define "admin/pagination" }}{{ end }}`)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, tmpl.ExecuteTemplate(&buf, "jobs/admin_list", map[string]any{
+		"Jobs":     nil, // empty list skips the pagination template (defined in admin)
+		"Status":   "",
+		"RawQuery": "",
+		"Worker":   view,
+	}))
+	return buf.String()
+}
+
+func TestAdminListCard_RendersRunningWorker(t *testing.T) {
+	view := workerStatusView{
+		Started: true, Running: true, Workers: 4, InFlight: 2,
+		LastPollAt: time.Now(),
+		Counts:     []statusCount{{StatusPending, 7}, {StatusRunning, 2}, {StatusFailed, 1}, {StatusDead, 0}, {StatusCompleted, 99}},
+	}
+	out := renderAdminList(t, view)
+	assert.Contains(t, out, "Worker Status")
+	assert.Contains(t, out, "Running")
+	assert.Contains(t, out, "4")  // worker count
+	assert.Contains(t, out, "99") // completed count
+	assert.NotContains(t, out, "Not Started")
+}
+
+func TestAdminListCard_RendersNotStarted(t *testing.T) {
+	view := workerStatusView{
+		Counts: []statusCount{{StatusPending, 0}, {StatusRunning, 0}, {StatusFailed, 0}, {StatusDead, 0}, {StatusCompleted, 0}},
+	}
+	out := renderAdminList(t, view)
+	assert.Contains(t, out, "Not Started")
+	// The worker-meta row (Workers/In Flight/Last Poll) is hidden when not started.
+	assert.NotContains(t, out, "In Flight")
+}
+
+func TestAdminListCard_RendersStaleBadge(t *testing.T) {
+	view := workerStatusView{
+		Started: true, Running: true, Stale: true, Workers: 1,
+		LastPollAt: time.Now().Add(-5 * time.Minute),
+		Counts:     []statusCount{{StatusPending, 0}, {StatusRunning, 0}, {StatusFailed, 0}, {StatusDead, 0}, {StatusCompleted, 0}},
+	}
+	out := renderAdminList(t, view)
+	// The "Stalled" badge text only appears when the stale branch renders.
+	assert.Equal(t, 1, strings.Count(out, ">Stalled<"), "stalled badge rendered exactly once")
+}
+
+func TestCountByStatus(t *testing.T) {
+	db := testDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	for range 3 {
+		_, err := repo.Enqueue(ctx, "task", `{}`, 3, 0, time.Now())
+		require.NoError(t, err)
+	}
+
+	counts, err := repo.CountByStatus(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, counts[StatusPending])
+	assert.Equal(t, 0, counts[StatusRunning])
+	assert.Equal(t, 0, counts[StatusDead])
+
+	// Claiming a job flips it from pending to running.
+	claimed, err := repo.Claim(ctx, "w1", 1)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	counts, err = repo.CountByStatus(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, counts[StatusPending])
+	assert.Equal(t, 1, counts[StatusRunning])
+}
+
+func countFor(view workerStatusView, s JobStatus) int {
+	for _, c := range view.Counts {
+		if c.Status == s {
+			return c.Count
+		}
+	}
+	return -1
+}
+
+func TestWorkerStatus_NilWorker(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.repo.Enqueue(context.Background(), "task", `{}`, 3, 0, time.Now())
+	require.NoError(t, err)
+
+	view, err := app.workerStatus(t.Context())
+	require.NoError(t, err)
+	assert.False(t, view.Started, "no worker => not started")
+	assert.Equal(t, 0, view.Workers)
+	require.Len(t, view.Counts, 5, "all five statuses always represented")
+	assert.Equal(t, 1, countFor(view, StatusPending))
+	assert.Equal(t, 0, countFor(view, StatusRunning))
+}
+
+func TestWorkerStatus_WithWorker(t *testing.T) {
+	app := newTestApp(t)
+	app.workerCfg = DefaultWorkerConfig()
+	app.worker = NewWorker(app.repo, app.handlers, app.workerCfg, nil)
+	app.worker.running.Store(true)
+	app.worker.lastPollAt.Store(time.Now().UnixNano())
+
+	view, err := app.workerStatus(t.Context())
+	require.NoError(t, err)
+	assert.True(t, view.Started)
+	assert.True(t, view.Running)
+	assert.Equal(t, app.workerCfg.NumWorkers, view.Workers)
+	assert.False(t, view.Stale, "fresh poll is not stale")
+}
+
+func TestWorkerStatus_StaleWorker(t *testing.T) {
+	app := newTestApp(t)
+	app.workerCfg = DefaultWorkerConfig()
+	app.worker = NewWorker(app.repo, app.handlers, app.workerCfg, nil)
+	app.worker.running.Store(true)
+	app.worker.lastPollAt.Store(time.Now().Add(-5 * time.Minute).UnixNano())
+
+	view, err := app.workerStatus(t.Context())
+	require.NoError(t, err)
+	assert.True(t, view.Stale, "5-minute-old poll is stale")
+}
+
+func TestAdminListJobs_IncludesWorkerStatus(t *testing.T) {
+	app := newTestApp(t)
+	_, err := app.repo.Enqueue(context.Background(), "task", `{}`, 3, 0, time.Now())
+	require.NoError(t, err)
+
+	var captured map[string]any
+	record := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := burrow.WithTemplateExecutor(r.Context(),
+				func(_ context.Context, _ string, data map[string]any) (template.HTML, error) {
+					captured = data
+					return "", nil
+				})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+
+	r := chi.NewRouter()
+	r.Use(record)
+	r.Get("/admin/jobs", burrow.Handle(app.adminListJobs))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/jobs", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, captured, "Worker")
+	view, ok := captured["Worker"].(workerStatusView)
+	require.True(t, ok, "Worker render value is a workerStatusView")
+	assert.False(t, view.Started)
+	assert.Len(t, view.Counts, 5)
+}

--- a/contrib/jobs/repository.go
+++ b/contrib/jobs/repository.go
@@ -208,6 +208,22 @@ func (r *Repository) FindByID(ctx context.Context, id string) (*Job, error) {
 	return r.GetByID(ctx, id)
 }
 
+// CountByStatus returns the number of jobs in each lifecycle status. Statuses
+// with no jobs are present with a zero count, so callers always get a complete
+// map. The counts back the admin worker-status panel.
+func (r *Repository) CountByStatus(ctx context.Context) (map[JobStatus]int, error) {
+	statuses := []JobStatus{StatusPending, StatusRunning, StatusFailed, StatusDead, StatusCompleted}
+	counts := make(map[JobStatus]int, len(statuses))
+	for _, s := range statuses {
+		n, err := den.NewQuery[Job](r.db).Where(where.Field("status").Eq(string(s))).Count(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("count jobs by status %q: %w", s, err)
+		}
+		counts[s] = int(n)
+	}
+	return counts, nil
+}
+
 // Delete deletes a job by ID (any status).
 func (r *Repository) Delete(ctx context.Context, id string) error {
 	job, err := den.FindByID[Job](ctx, r.db, id)

--- a/contrib/jobs/templates/admin_list.html
+++ b/contrib/jobs/templates/admin_list.html
@@ -9,6 +9,33 @@
 <header class="mb-4">
     <h2 class="text-2xl font-bold tracking-tight">{{ t "Jobs" }}</h2>
 </header>
+{{- $w := .Worker }}
+<section class="mb-6 rounded-lg border border-gray-200 p-4 dark:border-gray-800" aria-label="{{ t "Worker Status" }}">
+    <div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+        <div class="flex items-center gap-2">
+            <span class="font-medium text-gray-900 dark:text-gray-100">{{ t "Worker Status" }}</span>
+            {{- if not $w.Started }}
+            <span class="inline-block rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">{{ t "Not Started" }}</span>
+            {{- else if $w.Stale }}
+            <span class="inline-block rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/40 dark:text-red-200">{{ t "Stalled" }}</span>
+            {{- else if $w.Running }}
+            <span class="inline-block rounded bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200">{{ t "Running" }}</span>
+            {{- else }}
+            <span class="inline-block rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">{{ t "Stopped" }}</span>
+            {{- end }}
+        </div>
+        {{- if $w.Started }}
+        <div class="text-gray-600 dark:text-gray-400">{{ t "Workers" }}: <span class="font-medium text-gray-900 dark:text-gray-100">{{ $w.Workers }}</span></div>
+        <div class="text-gray-600 dark:text-gray-400">{{ t "In Flight" }}: <span class="font-medium text-gray-900 dark:text-gray-100">{{ $w.InFlight }}</span></div>
+        <div class="text-gray-600 dark:text-gray-400">{{ t "Last Poll" }}: <span class="font-medium text-gray-900 dark:text-gray-100">{{ $w.LastPollAt.Format "15:04:05" }}</span></div>
+        {{- end }}
+    </div>
+    <div class="mt-3 flex flex-wrap items-center gap-3">
+        {{- range $w.Counts }}
+        <span class="inline-flex items-center gap-1.5">{{ template "jobs/status_badge" .Status }}<span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ .Count }}</span></span>
+        {{- end }}
+    </div>
+</section>
 {{- $status := .Status }}
 <ul class="mb-6 flex flex-wrap items-center justify-end gap-x-4 gap-y-1 border-b border-gray-200 text-sm dark:border-gray-800" role="tablist">
     <li><a href="/admin/jobs" role="tab"{{ if eq $status "" }} aria-selected="true"{{ end }} class="-mb-px inline-block border-b-2 py-2 {{ if eq $status "" }}border-emerald-500 font-medium text-emerald-700 dark:text-emerald-400{{ else }}border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100{{ end }}">{{ t "All" }}</a></li>

--- a/contrib/jobs/translations/active.de.toml
+++ b/contrib/jobs/translations/active.de.toml
@@ -28,6 +28,13 @@ Status = "Status"
 Type = "Typ"
 "Updated At" = "Aktualisiert am"
 View = "Anzeigen"
+"Worker Status" = "Worker-Status"
+Workers = "Worker"
+"In Flight" = "In Bearbeitung"
+"Last Poll" = "Letzte Abfrage"
+"Not Started" = "Nicht gestartet"
+Stopped = "Gestoppt"
+Stalled = "Inaktiv"
 
 # Nachrichten (vollständige Sätze, Bestätigungen)
 admin-jobs-empty = "Keine Jobs gefunden."

--- a/contrib/jobs/translations/active.en.toml
+++ b/contrib/jobs/translations/active.en.toml
@@ -28,6 +28,13 @@ Status = "Status"
 Type = "Type"
 "Updated At" = "Updated At"
 View = "View"
+"Worker Status" = "Worker Status"
+Workers = "Workers"
+"In Flight" = "In Flight"
+"Last Poll" = "Last Poll"
+"Not Started" = "Not Started"
+Stopped = "Stopped"
+Stalled = "Stalled"
 
 # Messages (full sentences, prompts, confirmations)
 admin-jobs-empty = "No jobs found."


### PR DESCRIPTION
## Summary

The `/admin/jobs` page listed jobs but gave no view of the worker pool driving them. This adds a status card at the top of the page showing:

- **Pool state** — running / stopped / stalled (or "not started" before boot), derived from `Worker.Stats()` and the same staleness threshold the readiness check uses.
- **Worker count, in-flight jobs, last poll time** (shown only when a worker exists).
- **Per-status job counts** — pending / running / failed / dead / completed, reusing the existing `jobs/status_badge` block.

New `Repository.CountByStatus` returns a complete count map (zero-filled), and `App.workerStatus` assembles the view; both `pollStale` and `readinessThreshold` are reused from the readiness work rather than duplicated.

New translation keys are added to `en` + `de` (the stalled badge is "Stalled" / "Inaktiv").

## Test plan

- `Repository.CountByStatus` against a real DB (pending → running after Claim).
- `App.workerStatus`: nil worker → not started + counts still populated; running worker → live fields; stale worker → `Stale` true.
- `adminListJobs` threads the view into the render context (recording-executor handler test).
- Three `ExecuteTemplate` tests render the real card markup (running / not-started / stalled branches), since the auth gate hides this path from a live-server smoke test.
- Live smoke: `example/notes` boots (global template parse OK), `/admin/jobs` → 303 (auth redirect, no 500), `/healthz/ready` reports `jobs: ok`.
- `go test ./...` green incl. `-race`; `golangci-lint` 0 issues; translation divergence guard green.