### PR TITLE
feat(server): trust reverse-proxy X-Forwarded-Proto for request scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 - **contrib/jobs reports worker liveness through `/healthz/ready`.** The jobs app now implements `ReadinessChecker`, returning 503 with a `jobs` entry when the poller stalls so orchestrators stop routing to an instance that can no longer drain its queue.
 - **contrib/jobs admin: worker-status panel.** The `/admin/jobs` page now shows a card with the worker pool's state (running / stopped / stalled), worker count, in-flight jobs, last poll time, and per-status job counts.
+- **Reverse-proxy forwarded-headers support (`--forwarded-mode`, default `private`).** Behind a TLS-terminating proxy the framework now derives the request scheme from a trusted proxy's `X-Forwarded-Proto`, gated on the direct TCP peer: `private` (default) trusts loopback + RFC1918 — covering same-host nginx/Caddy with zero config — while `loopback`, `trusted-cidrs` (with `--forwarded-trusted-cidrs`), and `off` tune the trust boundary. New `burrow.RequestIsHTTPS(r)` reports the per-request scheme. Directly-served requests are unaffected — only requests whose TCP peer is loopback/RFC1918 consult the header.
 
 ### Fixed
 

--- a/app/config.go
+++ b/app/config.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,9 +25,27 @@ type ServerConfig struct {
 	PIDFile         string
 	AppName         string
 	ClientIP        ClientIPConfig
+	Forwarded       ForwardedConfig
 	Port            int
 	MaxBodySize     int // in MB
 	ShutdownTimeout int // in seconds
+}
+
+// ForwardedConfig controls whether the framework trusts a reverse proxy's
+// X-Forwarded-Proto (and optionally X-Forwarded-Host) to derive the public
+// request scheme — so CSRF, Secure cookies, and HSTS work behind a
+// TLS-terminating proxy. Trust is gated on the direct TCP peer. See
+// docs/guide/reverse-proxy.md.
+type ForwardedConfig struct {
+	// Mode is one of: "private" (default — trust loopback + RFC1918 + ULA
+	// peers), "loopback" (loopback only), "trusted-cidrs" (explicit allowlist
+	// via TrustedCIDRs), "off" (ignore forwarded headers entirely).
+	Mode string
+	// TrustedCIDRs is the explicit trusted-proxy allowlist (mode=trusted-cidrs).
+	TrustedCIDRs []string
+	// TrustHost, when true, also applies X-Forwarded-Host to r.Host. Off by
+	// default — Host injection enables cache poisoning / poisoned absolute URLs.
+	TrustHost bool
 }
 
 // ClientIPConfig selects how the framework extracts the client IP from
@@ -108,6 +127,11 @@ func NewConfig(cmd *cli.Command) *Config {
 				Header:         cmd.String("client-ip-header"),
 				TrustedProxies: int(cmd.Int("client-ip-trusted-proxies")),
 				TrustedCIDRs:   splitCSV(cmd.String("client-ip-trusted-cidrs")),
+			},
+			Forwarded: ForwardedConfig{
+				Mode:         cmd.String("forwarded-mode"),
+				TrustedCIDRs: splitCSV(cmd.String("forwarded-trusted-cidrs")),
+				TrustHost:    cmd.Bool("forwarded-trust-host"),
 			},
 		},
 		Database: DatabaseConfig{
@@ -220,6 +244,34 @@ func rejectClientIPCompanions(cip ClientIPConfig, allow string) error {
 		return fmt.Errorf("--client-ip-trusted-cidrs is only valid with --client-ip-mode=xff-trusted-cidrs")
 	}
 	return nil
+}
+
+// ValidateForwarded checks that the forwarded-headers configuration is
+// consistent. --forwarded-trusted-cidrs is only meaningful with
+// mode=trusted-cidrs, where it is required and each entry must parse. The
+// default and loopback modes use built-in prefixes; off disables the feature.
+// See docs/guide/reverse-proxy.md.
+func (c *Config) ValidateForwarded(_ *cli.Command) error {
+	f := c.Server.Forwarded
+	switch f.Mode {
+	case "", "private", "loopback", "off":
+		if len(f.TrustedCIDRs) != 0 {
+			return fmt.Errorf("--forwarded-trusted-cidrs is only valid with --forwarded-mode=trusted-cidrs")
+		}
+		return nil
+	case "trusted-cidrs":
+		if len(f.TrustedCIDRs) == 0 {
+			return fmt.Errorf("--forwarded-mode=trusted-cidrs requires --forwarded-trusted-cidrs (comma-separated CIDRs)")
+		}
+		for _, cidr := range f.TrustedCIDRs {
+			if _, err := netip.ParsePrefix(cidr); err != nil {
+				return fmt.Errorf("--forwarded-trusted-cidrs: invalid CIDR %q: %w", cidr, err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown forwarded mode: %q (valid: private, loopback, trusted-cidrs, off)", f.Mode)
+	}
 }
 
 // ValidateTLS checks that the TLS configuration is consistent.
@@ -358,6 +410,22 @@ func CoreFlags(configSource func(key string) cli.ValueSource) []cli.Flag {
 			Name:    "client-ip-trusted-cidrs",
 			Usage:   "Comma-separated CIDRs covering the trusted proxy fleet (with --client-ip-mode=xff-trusted-cidrs): e.g. 13.32.0.0/15,52.46.0.0/18.",
 			Sources: FlagSources(configSource, "CLIENT_IP_TRUSTED_CIDRS", "server.client_ip.trusted_cidrs"),
+		},
+		&cli.StringFlag{
+			Name:    "forwarded-mode",
+			Value:   "private",
+			Usage:   "Trust a reverse proxy's X-Forwarded-Proto for the request scheme (CSRF/Secure cookies/HSTS behind a TLS-terminating proxy). One of: private (trust loopback+RFC1918, default — covers same-host nginx/Caddy), loopback (loopback only), trusted-cidrs (explicit --forwarded-trusted-cidrs), off. See docs/guide/reverse-proxy.md.",
+			Sources: FlagSources(configSource, "FORWARDED_MODE", "server.forwarded.mode"),
+		},
+		&cli.StringFlag{
+			Name:    "forwarded-trusted-cidrs",
+			Usage:   "Comma-separated CIDRs of the trusted proxy (with --forwarded-mode=trusted-cidrs): e.g. a Cloudflare range or a single-tenant subnet.",
+			Sources: FlagSources(configSource, "FORWARDED_TRUSTED_CIDRS", "server.forwarded.trusted_cidrs"),
+		},
+		&cli.BoolFlag{
+			Name:    "forwarded-trust-host",
+			Usage:   "Also apply X-Forwarded-Host to the request host. Off by default — an attacker-controlled Host enables cache poisoning / poisoned absolute URLs. Only enable behind a proxy that overwrites this header.",
+			Sources: FlagSources(configSource, "FORWARDED_TRUST_HOST", "server.forwarded.trust_host"),
 		},
 		&cli.StringFlag{
 			Name:    "database-dsn",

--- a/app/context.go
+++ b/app/context.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"html/template"
+	"net/http"
 )
 
 // TemplateExecutor executes a named template with the given data and returns
@@ -31,6 +32,7 @@ type (
 	ctxKeyTemplateExecutor struct{}
 	ctxKeyAuthChecker      struct{}
 	ctxKeyRequestPath      struct{}
+	ctxKeyForwardedProto   struct{}
 )
 
 // WithContextValue returns a new context with the given key-value pair.
@@ -61,6 +63,33 @@ func Layout(ctx context.Context) string {
 		return name
 	}
 	return ""
+}
+
+// WithForwardedProto records the scheme a trusted reverse proxy reported via
+// X-Forwarded-Proto. It is set only by the server's forwarded-headers
+// middleware, and only after the TCP peer passed the trusted-CIDR check.
+func WithForwardedProto(ctx context.Context, scheme string) context.Context {
+	return context.WithValue(ctx, ctxKeyForwardedProto{}, scheme)
+}
+
+// ForwardedProto returns the scheme recorded by [WithForwardedProto], or "".
+func ForwardedProto(ctx context.Context) string {
+	if scheme, ok := ctx.Value(ctxKeyForwardedProto{}).(string); ok {
+		return scheme
+	}
+	return ""
+}
+
+// RequestIsHTTPS reports whether the request should be treated as HTTPS for
+// per-request security decisions (CSRF origin check, Secure cookies). It
+// consults the trusted forwarded-proto flag first, then falls back to r.TLS.
+// Behind a TLS-terminating proxy the connection is plain HTTP (r.TLS == nil),
+// so the forwarded flag is what makes the scheme correct.
+func RequestIsHTTPS(r *http.Request) bool {
+	if ForwardedProto(r.Context()) == "https" {
+		return true
+	}
+	return r.TLS != nil
 }
 
 // WithNavItems stores navigation items in the context.

--- a/app/forwarded_test.go
+++ b/app/forwarded_test.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestIsHTTPS(t *testing.T) {
+	t.Run("forwarded-proto https flag", func(t *testing.T) {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		r = r.WithContext(WithForwardedProto(r.Context(), "https"))
+		assert.True(t, RequestIsHTTPS(r))
+	})
+
+	t.Run("forwarded-proto http flag", func(t *testing.T) {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		r = r.WithContext(WithForwardedProto(r.Context(), "http"))
+		assert.False(t, RequestIsHTTPS(r))
+	})
+
+	t.Run("real TLS, no flag", func(t *testing.T) {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		r.TLS = &tls.ConnectionState{}
+		assert.True(t, RequestIsHTTPS(r))
+	})
+
+	t.Run("plain http, no flag", func(t *testing.T) {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+		assert.False(t, RequestIsHTTPS(r))
+	})
+}
+
+func TestForwardedProto_EmptyWhenUnset(t *testing.T) {
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	assert.Empty(t, ForwardedProto(r.Context()))
+}
+
+func TestValidateForwarded(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ForwardedConfig
+		wantErr string // substring; "" = no error
+	}{
+		{"default empty mode ok", ForwardedConfig{}, ""},
+		{"private ok no cidrs", ForwardedConfig{Mode: "private"}, ""},
+		{"loopback ok", ForwardedConfig{Mode: "loopback"}, ""},
+		{"off ok", ForwardedConfig{Mode: "off"}, ""},
+		{"trusted-cidrs valid", ForwardedConfig{Mode: "trusted-cidrs", TrustedCIDRs: []string{"10.0.0.0/8"}}, ""},
+		{"trusted-cidrs empty fails", ForwardedConfig{Mode: "trusted-cidrs"}, "requires --forwarded-trusted-cidrs"},
+		{"trusted-cidrs invalid cidr fails", ForwardedConfig{Mode: "trusted-cidrs", TrustedCIDRs: []string{"garbage"}}, "invalid CIDR"},
+		{"cidrs without trusted-cidrs mode fails", ForwardedConfig{Mode: "private", TrustedCIDRs: []string{"10.0.0.0/8"}}, "only valid with --forwarded-mode=trusted-cidrs"},
+		{"unknown mode fails", ForwardedConfig{Mode: "wat"}, "unknown forwarded mode"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{}
+			c.Server.Forwarded = tc.cfg
+			err := c.ValidateForwarded(nil)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/context.go
+++ b/context.go
@@ -2,11 +2,18 @@ package burrow
 
 import (
 	"context"
+	"net/http"
 	"net/netip"
 
 	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/oliverandrich/burrow/app"
 )
+
+// RequestIsHTTPS reports whether the request should be treated as HTTPS for
+// per-request security decisions (CSRF origin check, Secure cookies). Wrapper
+// around [app.RequestIsHTTPS]: it honors a trusted reverse proxy's
+// X-Forwarded-Proto (see --forwarded-mode) and falls back to r.TLS.
+func RequestIsHTTPS(r *http.Request) bool { return app.RequestIsHTTPS(r) }
 
 // WithLayout stores the layout template name in the context. Wrapper around
 // [app.WithLayout].

--- a/server/forwarded.go
+++ b/server/forwarded.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	"github.com/oliverandrich/burrow/app"
+)
+
+// loopbackPrefixes covers same-host reverse proxies (nginx/Caddy that reach the
+// app over 127.0.0.1 / ::1, e.g. Uberspace).
+var loopbackPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("::1/128"),
+}
+
+// privatePrefixes is the default trust set: loopback plus RFC1918 and IPv6 ULA,
+// covering same-host and private-network/Docker-bridge proxies. Public and CGNAT
+// (100.64.0.0/10 — shared hosting) peers are deliberately excluded. Declared
+// after loopbackPrefixes so the append picks up the initialised value.
+var privatePrefixes = append([]netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("fc00::/7"),
+}, loopbackPrefixes...)
+
+// resolveTrustedPrefixes maps the configured mode to its trusted-peer prefix
+// set. "off" (and an unparseable trusted-cidrs list) yields nil, which the
+// middleware treats as a no-op passthrough.
+func resolveTrustedPrefixes(cfg app.ForwardedConfig) []netip.Prefix {
+	switch cfg.Mode {
+	case "", "private":
+		return privatePrefixes
+	case "loopback":
+		return loopbackPrefixes
+	case "trusted-cidrs":
+		return parsePrefixes(cfg.TrustedCIDRs)
+	default: // "off" or unknown (validated at boot)
+		return nil
+	}
+}
+
+// parsePrefixes parses CIDR strings into masked prefixes, skipping any that
+// fail to parse (ValidateForwarded already rejected those at boot).
+func parsePrefixes(cidrs []string) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, c := range cidrs {
+		if p, err := netip.ParsePrefix(c); err == nil {
+			out = append(out, p.Masked())
+		}
+	}
+	return out
+}
+
+// peerInTrustedCIDRs reports whether the TCP peer (remoteAddr, "ip:port") falls
+// inside any trusted prefix. Malformed addresses return false (fail-closed);
+// IPv4-mapped IPv6 peers are unmapped so an IPv4 prefix matches.
+func peerInTrustedCIDRs(remoteAddr string, prefixes []netip.Prefix) bool {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	addr = addr.Unmap()
+	for _, p := range prefixes {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeProto extracts the first, lowercased token of an X-Forwarded-Proto
+// header and returns it only if it is a recognised scheme ("https"/"http").
+func normalizeProto(raw string) string {
+	if i := strings.IndexByte(raw, ','); i >= 0 {
+		raw = raw[:i]
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "https":
+		return "https"
+	case "http":
+		return "http"
+	default:
+		return ""
+	}
+}
+
+// forwardedHeadersMiddleware trusts a reverse proxy's X-Forwarded-Proto (and,
+// when enabled, X-Forwarded-Host) ONLY when the direct TCP peer is inside the
+// configured trusted-CIDR set. It is upgrade-only: it never clears an existing
+// r.TLS, so a genuine TLS connection cannot be downgraded by a forwarded http
+// header. When no peers are trusted (mode=off) it is a no-op passthrough.
+func forwardedHeadersMiddleware(cfg app.ForwardedConfig) func(http.Handler) http.Handler {
+	prefixes := resolveTrustedPrefixes(cfg)
+	if len(prefixes) == 0 {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	trustHost := cfg.TrustHost
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if peerInTrustedCIDRs(r.RemoteAddr, prefixes) {
+				if proto := normalizeProto(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+					r.URL.Scheme = proto
+					r = r.WithContext(app.WithForwardedProto(r.Context(), proto))
+					if proto == "https" && r.TLS == nil {
+						// Sentinel: consumers must only check r.TLS != nil,
+						// never read certificate fields off it.
+						r.TLS = &tls.ConnectionState{}
+					}
+				}
+				if trustHost {
+					if host := r.Header.Get("X-Forwarded-Host"); host != "" {
+						r.Host = host
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server/forwarded_test.go
+++ b/server/forwarded_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/oliverandrich/burrow/app"
+	"github.com/stretchr/testify/assert"
+)
+
+// runForwarded sends req through forwardedHeadersMiddleware(cfg) and returns
+// the (possibly mutated) request the inner handler saw.
+func runForwarded(t *testing.T, cfg app.ForwardedConfig, req *http.Request) *http.Request {
+	t.Helper()
+	var got *http.Request
+	h := forwardedHeadersMiddleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return got
+}
+
+func proxiedReq(remoteAddr, proto string) *http.Request {
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.test/", nil)
+	r.RemoteAddr = remoteAddr
+	if proto != "" {
+		r.Header.Set("X-Forwarded-Proto", proto)
+	}
+	return r
+}
+
+func TestForwarded_PublicPeerIgnored(t *testing.T) {
+	// Headline spoofing defense: an untrusted public peer cannot forge the scheme.
+	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, proxiedReq("203.0.113.5:1234", "https"))
+	assert.Nil(t, got.TLS, "public peer's X-Forwarded-Proto must be ignored")
+	assert.Empty(t, app.ForwardedProto(got.Context()))
+}
+
+func TestForwarded_CGNATPeerIgnored(t *testing.T) {
+	// Shared-hosting (Uberspace 100.64/10) neighbours must not be trusted by default.
+	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, proxiedReq("100.64.60.2:1234", "https"))
+	assert.Nil(t, got.TLS)
+}
+
+func TestForwarded_DefaultPrivate_LoopbackTrusted(t *testing.T) {
+	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, proxiedReq("127.0.0.1:5000", "https"))
+	assert.NotNil(t, got.TLS, "loopback proxy is trusted under private mode")
+	assert.Equal(t, "https", got.URL.Scheme)
+	assert.Equal(t, "https", app.ForwardedProto(got.Context()))
+	assert.True(t, app.RequestIsHTTPS(got))
+}
+
+func TestForwarded_DefaultPrivate_RFC1918Trusted(t *testing.T) {
+	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, proxiedReq("10.1.2.3:5000", "https"))
+	assert.NotNil(t, got.TLS)
+	assert.Equal(t, "https", app.ForwardedProto(got.Context()))
+}
+
+func TestForwarded_NoDowngrade(t *testing.T) {
+	// A genuine TLS connection must not be downgraded by X-Forwarded-Proto: http.
+	req := proxiedReq("127.0.0.1:5000", "http")
+	req.TLS = &tls.ConnectionState{}
+	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, req)
+	assert.NotNil(t, got.TLS, "existing r.TLS must survive an http forwarded-proto")
+}
+
+func TestForwarded_LoopbackMode(t *testing.T) {
+	cfg := app.ForwardedConfig{Mode: "loopback"}
+	assert.Nil(t, runForwarded(t, cfg, proxiedReq("10.1.2.3:5000", "https")).TLS, "loopback mode rejects RFC1918")
+	assert.NotNil(t, runForwarded(t, cfg, proxiedReq("127.0.0.1:5000", "https")).TLS, "loopback mode trusts loopback")
+}
+
+func TestForwarded_OffMode(t *testing.T) {
+	got := runForwarded(t, app.ForwardedConfig{Mode: "off"}, proxiedReq("127.0.0.1:5000", "https"))
+	assert.Nil(t, got.TLS, "off mode ignores forwarded headers from any peer")
+}
+
+func TestForwarded_TrustHostGate(t *testing.T) {
+	mk := func() *http.Request {
+		r := proxiedReq("127.0.0.1:5000", "https")
+		r.Header.Set("X-Forwarded-Host", "public.example.com")
+		return r
+	}
+	off := runForwarded(t, app.ForwardedConfig{Mode: "private"}, mk())
+	assert.Equal(t, "example.test", off.Host, "X-Forwarded-Host ignored without trust-host")
+
+	on := runForwarded(t, app.ForwardedConfig{Mode: "private", TrustHost: true}, mk())
+	assert.Equal(t, "public.example.com", on.Host, "X-Forwarded-Host honored with trust-host")
+}
+
+func TestPeerInTrustedCIDRs(t *testing.T) {
+	private := privatePrefixes
+	tests := []struct {
+		name       string
+		remoteAddr string
+		prefixes   []netip.Prefix
+		want       bool
+	}{
+		{"loopback v4", "127.0.0.1:80", private, true},
+		{"loopback v6", "[::1]:80", private, true},
+		{"rfc1918 in", "10.1.2.3:80", private, true},
+		{"rfc1918 192.168 in", "192.168.1.1:80", private, true},
+		{"public out", "203.0.113.5:80", private, false},
+		{"cgnat out", "100.64.60.2:80", private, false},
+		{"ula v6 in", "[fd00::1]:80", private, true},
+		{"v4-mapped-v6", "[::ffff:10.0.0.1]:80", private, true},
+		{"missing port", "10.0.0.1", private, true},
+		{"malformed", "not-an-addr", private, false},
+		{"loopback-only set rejects rfc1918", "10.0.0.1:80", loopbackPrefixes, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, peerInTrustedCIDRs(tc.remoteAddr, tc.prefixes))
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -212,6 +212,7 @@ func (s *Server) Run(ctx context.Context, cmd *cli.Command) error {
 	}))
 	r.Use(chimw.RequestID)
 	r.Use(clientIPMiddleware(cfg.Server.ClientIP))
+	r.Use(forwardedHeadersMiddleware(cfg.Server.Forwarded))
 	r.Use(chimw.Compress(5))
 	r.Use(chimw.RequestSize(int64(cfg.Server.MaxBodySize) * 1024 * 1024))
 	r.Use(s.i18nBundle.LocaleMiddleware())
@@ -278,6 +279,10 @@ func (s *Server) boot(ctx context.Context, cmd *cli.Command) (*burrowapp.Config,
 	}
 
 	if err := cfg.ValidateClientIP(cmd); err != nil {
+		return nil, nil, err
+	}
+
+	if err := cfg.ValidateForwarded(cmd); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
## Summary

PR 1 of 4 for the reverse-proxy forwarded-headers feature. Behind a TLS-terminating proxy (nginx, Caddy, Cloudflare, ngrok) the connection to the app is plain HTTP, so `r.TLS == nil` and the per-request scheme is wrong — which breaks CSRF origin checks, Secure cookies, and HSTS. This PR lays the core mechanism; the consumers that act on it follow.

- **Peer-gated middleware** (`server/forwarded.go`): for trusted TCP peers, sets `r.URL.Scheme`, an `r.TLS` sentinel (https only), and a context flag from `X-Forwarded-Proto`. Upgrade-only — never clears a genuine `r.TLS`. Own `net/netip` peer-in-CIDR matcher (chi's XFF middleware doesn't expose one).
- **`--forwarded-mode`** (default `private`): trusts loopback + RFC1918 — same-host nginx/Caddy works with zero config. Other modes: `loopback`, `trusted-cidrs` (+`--forwarded-trusted-cidrs`), `off`. CGNAT/public peers (incl. shared-hosting `100.64/10`) are excluded by default. `--forwarded-trust-host` (default off) gates `X-Forwarded-Host`.
- **`burrow.RequestIsHTTPS(r)`**: forwarded-proto flag first, else `r.TLS`. Re-exported from the root package.
- `ValidateForwarded` mirrors `ValidateClientIP` (mode validity; `trusted-cidrs` requires CIDRs that parse; companion rejection).

Dormant by design: no consumer reads `RequestIsHTTPS` yet, so behavior is inert until the csrf/session/secure changes land.

## Test plan

- `server/forwarded_test.go`: public/CGNAT peer ignored (spoofing defense), loopback + RFC1918 trusted under `private`, `loopback`/`off` modes, no-downgrade of genuine TLS, trust-host gate, and a `peerInTrustedCIDRs` table (v4/v6/ULA/v4-mapped/missing-port/malformed).
- `app/forwarded_test.go`: `RequestIsHTTPS` matrix and `ValidateForwarded` (empty/invalid CIDRs, companion-without-mode, unknown mode).
- `go test ./... -race` green; `golangci-lint` 0 issues.