### PR TITLE
fix(csrf): derive origin-check scheme per-request, not from base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 - **contrib/jobs admin: worker-status panel.** The `/admin/jobs` page now shows a card with the worker pool's state (running / stopped / stalled), worker count, in-flight jobs, last poll time, and per-status job counts.
 - **Reverse-proxy forwarded-headers support (`--forwarded-mode`, default `private`).** Behind a TLS-terminating proxy the framework now derives the request scheme from a trusted proxy's `X-Forwarded-Proto`, gated on the direct TCP peer: `private` (default) trusts loopback + RFC1918 — covering same-host nginx/Caddy with zero config — while `loopback`, `trusted-cidrs` (with `--forwarded-trusted-cidrs`), and `off` tune the trust boundary. New `burrow.RequestIsHTTPS(r)` reports the per-request scheme. Directly-served requests are unaffected — only requests whose TCP peer is loopback/RFC1918 consult the header.
 
+### Changed
+
+- **contrib/csrf derives the request scheme per-request.** The CSRF origin/referer check now treats a request as HTTPS via `burrow.RequestIsHTTPS(r)` (which honors a trusted proxy's `X-Forwarded-Proto`) instead of the boot-time base-URL scheme. Behind a reverse proxy this fixes the `403 "origin invalid"` that rejected browser POSTs whose `Origin` was `https` while the app saw plain HTTP. The CSRF cookie's own `Secure` attribute still follows the base-URL scheme (gorilla/csrf sets it once at startup).
+
 ### Fixed
 
 - **Background loops no longer crash the process on panic.** The auth orphaned-user/email-token sweep, the WebAuthn session sweep, the rate-limiter eviction sweep, the jobs poller, and the SIGHUP graceful-restart handler now recover per-iteration panics (logged with a stack trace) instead of letting the goroutine panic propagate unrecovered.

--- a/contrib/csrf/app.go
+++ b/contrib/csrf/app.go
@@ -72,11 +72,14 @@ func (a *App) configure(keyHex string, secure bool) error {
 		return err
 	}
 
+	// a.secure is the boot-time cookie Secure attribute (gorilla sets it once
+	// here). The per-request HTTPS decision for the origin check lives in
+	// csrfMiddleware via burrow.RequestIsHTTPS.
 	a.secure = secure
 	a.exempt = buildExemptMatcher(a.registry)
 	a.protect = gorillacsrf.Protect(
 		key,
-		gorillacsrf.Secure(secure),
+		gorillacsrf.Secure(a.secure),
 		gorillacsrf.SameSite(gorillacsrf.SameSiteLaxMode),
 		gorillacsrf.Path("/"),
 		gorillacsrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,10 +126,13 @@ func (a *App) csrfMiddleware(next http.Handler) http.Handler {
 		if a.exempt.matches(r.URL.Path) {
 			r = gorillacsrf.UnsafeSkipCheck(r)
 		}
-		// gorilla/csrf assumes HTTPS by default. For plaintext HTTP
-		// deployments, mark each request so gorilla skips HTTPS-only
-		// referer checks.
-		if !a.secure {
+		// gorilla/csrf assumes HTTPS by default and decides plaintext-vs-secure
+		// solely from this flag. Mark genuinely-plaintext requests so it skips
+		// the HTTPS-only origin/referer checks. The decision is per-request
+		// (RequestIsHTTPS honors a trusted proxy's X-Forwarded-Proto), not the
+		// boot-static scheme — otherwise an https request proxied to a plain-HTTP
+		// app is treated as http and its https Origin is rejected.
+		if !burrow.RequestIsHTTPS(r) {
 			r = gorillacsrf.PlaintextHTTPRequest(r)
 		}
 		wrapped.ServeHTTP(w, r)

--- a/contrib/csrf/app_test.go
+++ b/contrib/csrf/app_test.go
@@ -10,6 +10,7 @@ import (
 
 	gorillacsrf "github.com/gorilla/csrf"
 	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/app"
 	"github.com/oliverandrich/burrow/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -498,4 +499,69 @@ func TestExemptPaths_GetOnExemptPathStillSucceeds(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestCSRF_ProxiedPOSTPasses pins the load-bearing fix: behind a trusted proxy
+// (forwarded-proto=https) a browser POST whose Origin is https passes, where an
+// http-base-url app rejected it with "origin invalid" before. gorilla decides
+// http-vs-https purely from the PlaintextHTTPRequest flag, so the per-request
+// RequestIsHTTPS gate — not the boot-static a.secure — is what makes this work.
+func TestCSRF_ProxiedPOSTPasses(t *testing.T) {
+	a := newTestApp(t) // a.secure == false (HTTP base URL)
+
+	var token string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token = gorillacsrf.Token(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := a.Middleware()[0](inner)
+
+	// GET carries the forwarded-proto flag the server middleware would set.
+	getReq := httptest.NewRequestWithContext(app.WithForwardedProto(t.Context(), "https"), http.MethodGet, "http://example.com/", nil)
+	getRR := httptest.NewRecorder()
+	handler.ServeHTTP(getRR, getReq)
+	require.NotEmpty(t, token)
+
+	postReq := httptest.NewRequestWithContext(app.WithForwardedProto(t.Context(), "https"), http.MethodPost, "http://example.com/", strings.NewReader("x=1"))
+	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postReq.Header.Set("X-CSRF-Token", token)
+	postReq.Header.Set("Origin", "https://example.com")
+	for _, c := range getRR.Result().Cookies() {
+		postReq.AddCookie(c)
+	}
+	postRR := httptest.NewRecorder()
+	handler.ServeHTTP(postRR, postReq)
+
+	assert.Equal(t, http.StatusOK, postRR.Code, "proxied https POST must pass the origin check")
+}
+
+// TestCSRF_HTTPSOriginRejectedWithoutForwardedFlag is the negative control: the
+// same POST without the trusted-proxy signal is treated as plaintext, so the
+// https Origin mismatches the computed http origin and gorilla returns 403.
+func TestCSRF_HTTPSOriginRejectedWithoutForwardedFlag(t *testing.T) {
+	a := newTestApp(t)
+
+	var token string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token = gorillacsrf.Token(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := a.Middleware()[0](inner)
+
+	getReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", nil)
+	getRR := httptest.NewRecorder()
+	handler.ServeHTTP(getRR, getReq)
+	require.NotEmpty(t, token)
+
+	postReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.com/", strings.NewReader("x=1"))
+	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postReq.Header.Set("X-CSRF-Token", token)
+	postReq.Header.Set("Origin", "https://example.com")
+	for _, c := range getRR.Result().Cookies() {
+		postReq.AddCookie(c)
+	}
+	postRR := httptest.NewRecorder()
+	handler.ServeHTTP(postRR, postReq)
+
+	assert.Equal(t, http.StatusForbidden, postRR.Code, "no trusted-proxy signal => plaintext origin check rejects the https Origin")
 }


### PR DESCRIPTION
## Summary

PR 2 of 4 for the reverse-proxy forwarded-headers feature — the load-bearing fix. Behind a TLS-terminating proxy, gorilla/csrf decided plaintext-vs-secure **solely** from its `PlaintextHTTPRequest` flag (it ignores `r.URL.Scheme`/`r.TLS`). Burrow set that flag from the boot-time base-URL scheme, so an app with an HTTP base URL behind an HTTPS proxy computed an `http` origin and rejected browser POSTs whose `Origin` was `https` with `403 "origin invalid"` (the symptom seen registering passkeys over an ngrok tunnel).

The csrf middleware now decides per request via `burrow.RequestIsHTTPS(r)` (PR1), which honors a trusted proxy's `X-Forwarded-Proto`. The csrf cookie's own `Secure` attribute still follows the base-URL scheme — gorilla/csrf sets it once at startup.

## Test plan

- `TestCSRF_ProxiedPOSTPasses`: with the forwarded-proto signal, a browser POST (`Origin: https://…`) over a plain-HTTP hop passes — it returned 403 before the fix.
- `TestCSRF_HTTPSOriginRejectedWithoutForwardedFlag`: negative control — without the trusted-proxy signal the plaintext origin check still rejects the https Origin (403), proving the gate is what flips the behavior. (Both use `http://` request URLs because `httptest.NewRequest` auto-sets `r.TLS` for https URLs, which would mask the signal.)
- `go test ./... -race` green; `golangci-lint` 0 issues.