### PR TITLE
feat(session,secure): honor proxied request scheme for cookies and HSTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Burrow are documented here. The format is based on [Keep 
 
 ### Changed
 
+- **contrib/session and contrib/secure honor the proxied request scheme.** Session cookies are now marked `Secure` for HTTPS requests detected via `burrow.RequestIsHTTPS(r)`, even when the app's base URL is plain `http` (upgrade-only — an https base URL is never downgraded). `contrib/secure` emits HSTS for those requests only when `--forwarded-mode` is explicitly enabled.
 - **contrib/csrf derives the request scheme per-request.** The CSRF origin/referer check now treats a request as HTTPS via `burrow.RequestIsHTTPS(r)` (which honors a trusted proxy's `X-Forwarded-Proto`) instead of the boot-time base-URL scheme. Behind a reverse proxy this fixes the `403 "origin invalid"` that rejected browser POSTs whose `Origin` was `https` while the app saw plain HTTP. The CSRF cookie's own `Secure` attribute still follows the base-URL scheme (gorilla/csrf sets it once at startup).
 
 ### Fixed

--- a/contrib/secure/app.go
+++ b/contrib/secure/app.go
@@ -106,7 +106,7 @@ func (a *App) Flags(configSource func(key string) cli.ValueSource) []cli.Flag {
 }
 
 func (a *App) Configure(cfg *burrow.AppConfig, cmd *cli.Command) error {
-	isHTTPS := cfg.Config != nil && cfg.Config.IsHTTPS()
+	isHTTPS := secureHTTPSCapable(cfg, cmd != nil && cmd.IsSet("forwarded-mode"))
 
 	if a.csp == nil {
 		if v := cmd.String("secure-csp"); v != "" {
@@ -147,6 +147,25 @@ func (a *App) Configure(cfg *burrow.AppConfig, cmd *cli.Command) error {
 
 	a.configure(isHTTPS)
 	return nil
+}
+
+// secureHTTPSCapable reports whether the deployment should populate HTTPS
+// response-security options (HSTS, and production mode rather than dev mode).
+// True when the base URL is https, or when the operator explicitly opted into
+// reverse-proxy forwarded headers (a non-off --forwarded-mode) — the public
+// edge is then HTTPS even if the app's own URL is http, and per-request HSTS
+// emission stays gated by unrolled/secure's isSSL, which the forwarded
+// middleware satisfies. The default (unset) forwarded mode is deliberately not
+// treated as a proxy signal, so a plain local http deployment keeps its
+// development-mode defaults.
+func secureHTTPSCapable(cfg *burrow.AppConfig, forwardedExplicit bool) bool {
+	if cfg == nil || cfg.Config == nil {
+		return false
+	}
+	if cfg.Config.IsHTTPS() {
+		return true
+	}
+	return forwardedExplicit && cfg.Config.Server.Forwarded.Mode != "off"
 }
 
 // configure builds the unrolled/secure middleware. Extracted for testability.

--- a/contrib/secure/forwarded_test.go
+++ b/contrib/secure/forwarded_test.go
@@ -1,0 +1,45 @@
+package secure
+
+import (
+	"testing"
+
+	"github.com/oliverandrich/burrow"
+	"github.com/oliverandrich/burrow/app"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecureHTTPSCapable(t *testing.T) {
+	httpsCfg := &burrow.AppConfig{Config: &burrow.Config{}}
+	httpsCfg.Config.Server.BaseURL = "https://example.com"
+
+	httpCfg := func(mode string) *burrow.AppConfig {
+		c := &burrow.AppConfig{Config: &burrow.Config{}}
+		c.Config.Server.BaseURL = "http://localhost:8080"
+		c.Config.Server.Forwarded = app.ForwardedConfig{Mode: mode}
+		return c
+	}
+
+	tests := []struct {
+		name       string
+		cfg        *burrow.AppConfig
+		forwardedX bool
+		want       bool
+	}{
+		{"https base url", httpsCfg, false, true},
+		{"http base, forwarded explicit private", httpCfg("private"), true, true},
+		{"http base, forwarded explicit loopback", httpCfg("loopback"), true, true},
+		{"http base, forwarded default (not explicit)", httpCfg("private"), false, false},
+		{"http base, forwarded explicit off", httpCfg("off"), true, false},
+		{"http base, no forwarded", httpCfg(""), false, false},
+		{"nil config", &burrow.AppConfig{}, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, secureHTTPSCapable(tc.cfg, tc.forwardedX))
+		})
+	}
+}
+
+// Note: that secureHTTPSCapable==true populates HSTS opts (configure(true) emits
+// Strict-Transport-Security on an SSL request) is already pinned by
+// TestHSTSEnabledForHTTPS; no need to duplicate that here.

--- a/contrib/session/app.go
+++ b/contrib/session/app.go
@@ -85,7 +85,14 @@ func (a *App) Middleware() []func(http.Handler) http.Handler {
 func (a *App) sessionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		values, _ := a.manager.Parse(r)
-		s := &state{manager: a.manager, values: values}
+		// Secure when the boot config says HTTPS or the request arrived over
+		// HTTPS (directly or via a trusted proxy's X-Forwarded-Proto).
+		// Upgrade-only: the boot default is the floor, never downgraded.
+		s := &state{
+			manager: a.manager,
+			values:  values,
+			secure:  a.manager.secure || burrow.RequestIsHTTPS(r),
+		}
 		ctx := context.WithValue(r.Context(), ctxKeySession{}, s)
 		dw := &deferredWriter{ResponseWriter: w, state: s}
 		next.ServeHTTP(dw, r.WithContext(ctx))

--- a/contrib/session/context.go
+++ b/contrib/session/context.go
@@ -43,6 +43,12 @@ type state struct {
 	manager *Manager
 	values  map[string]any
 	dirty   bool
+	// secure is the per-request Secure-cookie decision, set by the middleware
+	// from burrow.RequestIsHTTPS (which honors a trusted proxy's
+	// X-Forwarded-Proto). It overrides the manager's boot-time default so a
+	// request proxied over HTTPS gets a Secure cookie even when the app's own
+	// base URL is http. Upgrade-only: it never drops below the boot default.
+	secure bool
 }
 
 // flush writes the session cookie if any values have changed. Called
@@ -56,6 +62,7 @@ func (s *state) flush(w http.ResponseWriter) {
 		slog.Error("session: failed to encode cookie", "error", err)
 		return
 	}
+	cookie.Secure = s.secure
 	http.SetCookie(w, cookie)
 }
 
@@ -152,8 +159,10 @@ func Clear(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.values = nil
-	s.dirty = false // explicit clear, not a deferred write
-	http.SetCookie(w, s.manager.Clear())
+	s.dirty = false             // explicit clear, not a deferred write
+	cookie := s.manager.Clear() //nolint:gosec // Secure is set per-request below; insecure is allowed for plain HTTP, as in Manager.Save
+	cookie.Secure = s.secure
+	http.SetCookie(w, cookie)
 }
 
 // Inject sets up session state in the request context without the full middleware.

--- a/contrib/session/forwarded_test.go
+++ b/contrib/session/forwarded_test.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/securecookie"
+	"github.com/oliverandrich/burrow/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sessionCookie(t *testing.T, rec *httptest.ResponseRecorder) *http.Cookie {
+	t.Helper()
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "_session" {
+			return c
+		}
+	}
+	t.Fatal("no _session cookie in response")
+	return nil
+}
+
+// TestSession_SecureCookieUnderForwardedHTTPS: boot config is HTTP (secure
+// false), but a request proxied over HTTPS (forwarded-proto flag) must still
+// get a Secure session cookie.
+func TestSession_SecureCookieUnderForwardedHTTPS(t *testing.T) {
+	r, sApp := routerWithSession(t)
+	require.False(t, sApp.manager.secure, "boot default is insecure (no https base URL)")
+
+	r.Get("/set", func(w http.ResponseWriter, req *http.Request) {
+		assert.NoError(t, Set(w, req, "k", "v"))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequestWithContext(app.WithForwardedProto(t.Context(), "https"), http.MethodGet, "/set", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.True(t, sessionCookie(t, rec).Secure, "forwarded-https request gets a Secure cookie")
+}
+
+func TestSession_PlainHTTPStaysInsecure(t *testing.T) {
+	r, _ := routerWithSession(t)
+	r.Get("/set", func(w http.ResponseWriter, req *http.Request) {
+		assert.NoError(t, Set(w, req, "k", "v"))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/set", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.False(t, sessionCookie(t, rec).Secure, "plain HTTP request keeps an insecure cookie")
+}
+
+func TestSession_ClearHonorsForwardedSecure(t *testing.T) {
+	r, _ := routerWithSession(t)
+	r.Get("/clear", func(w http.ResponseWriter, req *http.Request) {
+		Clear(w, req)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequestWithContext(app.WithForwardedProto(t.Context(), "https"), http.MethodGet, "/clear", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	c := sessionCookie(t, rec)
+	assert.True(t, c.Secure, "deletion cookie is Secure under forwarded-https")
+	assert.Equal(t, -1, c.MaxAge, "Clear writes a deletion cookie")
+}
+
+// TestSession_HTTPSBootNotDowngraded: an https-configured app must keep Secure
+// cookies even on a stray plain-HTTP request (upgrade-only — boot is the floor).
+func TestSession_HTTPSBootNotDowngraded(t *testing.T) {
+	sc := securecookie.New(make([]byte, 32), nil)
+	sc.MaxAge(3600)
+	a := &App{manager: &Manager{sc: sc, cookieName: "_session", maxAge: 3600, secure: true}}
+
+	r := chi.NewRouter()
+	r.Use(a.Middleware()[0])
+	r.Get("/set", func(w http.ResponseWriter, req *http.Request) {
+		assert.NoError(t, Set(w, req, "k", "v"))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/set", nil) // no forwarded flag, r.TLS nil
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.True(t, sessionCookie(t, rec).Secure, "https boot default is never downgraded")
+}


### PR DESCRIPTION
## Summary

PR 3 of 4 for the reverse-proxy forwarded-headers feature — the session and secure consumers.

- **contrib/session:** `state` carries a per-request `secure` flag set in the middleware to `manager.secure || burrow.RequestIsHTTPS(r)` (upgrade-only — an https base URL is never downgraded). `flush()` and `Clear()` apply it to the cookie's `Secure` attribute, so a request proxied over HTTPS gets a Secure session cookie even when the base URL is plain `http`. `Manager.secure` stays the boot fallback for direct callers / `Inject`.
- **contrib/secure:** `Configure` derives HTTPS-capability via a pure `secureHTTPSCapable(cfg, forwardedExplicit)` — https base URL, or an explicitly-set non-`off` `--forwarded-mode`. The default (zero-config) `private` mode is deliberately **not** treated as a proxy signal, so local http development keeps its dev-mode defaults (no surprise SSL redirect / host checks). HSTS then emits on requests unrolled/secure sees as SSL, which the forwarded middleware satisfies.

## Test plan

- session: Secure cookie under forwarded-https; plain-http stays insecure; `Clear` honors it; https-boot is never downgraded on a stray http request.
- secure: `secureHTTPSCapable` table (https base, explicit private/loopback, default-not-explicit → false, explicit `off` → false, no forwarded, nil config). HSTS-opt population stays covered by the existing `TestHSTSEnabledForHTTPS`.
- `go test ./... -race` green; `golangci-lint` 0 issues.