### PR TITLE
fix(server): don't set r.URL.Scheme in forwarded middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- **Reverse-proxy forwarded headers no longer corrupt the request URL (regression from 0.29.0).** Behind a trusted proxy reporting `X-Forwarded-Proto`, the middleware set `r.URL.Scheme` on an origin-form server request (no host), so `r.URL.String()` became `https:///path` — polluting request logs and any absolute URL built from `r.URL`. `r.URL` is now left untouched; read the proxied scheme via `burrow.RequestIsHTTPS(r)` as before.
+
 ## 0.29.0 — 2026-06-04
 
 ### Added

--- a/docs/guide/reverse-proxy.md
+++ b/docs/guide/reverse-proxy.md
@@ -35,7 +35,7 @@ Set `--base-url` to your public `https://…` URL regardless of mode — it driv
 
 ## What it does (and doesn't) touch
 
-When the peer is trusted, the middleware sets `r.URL.Scheme`, installs a sentinel `r.TLS`, and records the scheme so `burrow.RequestIsHTTPS(r)` reports HTTPS. It is **upgrade-only**: an `X-Forwarded-Proto: http` never clears a genuine TLS connection.
+When the peer is trusted, the middleware records the scheme in the request context and installs a sentinel `r.TLS` (for HTTPS), so `burrow.RequestIsHTTPS(r)` reports HTTPS. It leaves `r.URL` untouched — a server request's URL is origin-form (path only), so the public scheme/host belong in `--base-url`, not on `r.URL`. It is **upgrade-only**: an `X-Forwarded-Proto: http` never clears a genuine TLS connection.
 
 - **CSRF** consults `burrow.RequestIsHTTPS(r)` for its origin check — the `403` disappears.
 - **Sessions** mark the cookie `Secure` for forwarded-HTTPS requests (never downgrading an https base URL).

--- a/server/forwarded.go
+++ b/server/forwarded.go
@@ -108,7 +108,13 @@ func forwardedHeadersMiddleware(cfg app.ForwardedConfig) func(http.Handler) http
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if peerInTrustedCIDRs(r.RemoteAddr, prefixes) {
 				if proto := normalizeProto(r.Header.Get("X-Forwarded-Proto")); proto != "" {
-					r.URL.Scheme = proto
+					// The scheme is signaled via the context flag (read by
+					// burrow.RequestIsHTTPS) and the r.TLS sentinel (read by
+					// unrolled/secure's isSSL). We deliberately do NOT touch
+					// r.URL.Scheme: a server request's URL is origin-form (no
+					// host), so setting only the scheme would make
+					// r.URL.String() return "https:///path" and corrupt logs
+					// and any absolute URL built from r.URL.
 					r = r.WithContext(app.WithForwardedProto(r.Context(), proto))
 					if proto == "https" && r.TLS == nil {
 						// Sentinel: consumers must only check r.TLS != nil,

--- a/server/forwarded_test.go
+++ b/server/forwarded_test.go
@@ -50,9 +50,26 @@ func TestForwarded_CGNATPeerIgnored(t *testing.T) {
 func TestForwarded_DefaultPrivate_LoopbackTrusted(t *testing.T) {
 	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, proxiedReq("127.0.0.1:5000", "https"))
 	assert.NotNil(t, got.TLS, "loopback proxy is trusted under private mode")
-	assert.Equal(t, "https", got.URL.Scheme)
 	assert.Equal(t, "https", app.ForwardedProto(got.Context()))
 	assert.True(t, app.RequestIsHTTPS(got))
+}
+
+func TestForwarded_DoesNotCorruptURL(t *testing.T) {
+	// A real server request carries an origin-form URL (no scheme/host; the
+	// host lives in r.Host). Setting r.URL.Scheme alone would make
+	// r.URL.String() return "https:///auth/login" and pollute logs / absolute
+	// URLs. The scheme signal must flow via the context flag + r.TLS sentinel
+	// instead, leaving r.URL untouched.
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/auth/login", nil)
+	r.RemoteAddr = "127.0.0.1:5000"
+	r.Header.Set("X-Forwarded-Proto", "https")
+
+	got := runForwarded(t, app.ForwardedConfig{Mode: "private"}, r)
+
+	assert.Equal(t, "/auth/login", got.URL.String(), "origin-form request URL must stay intact")
+	assert.Empty(t, got.URL.Scheme)
+	assert.True(t, app.RequestIsHTTPS(got), "scheme still signaled via context flag")
+	assert.NotNil(t, got.TLS, "and via the r.TLS sentinel")
 }
 
 func TestForwarded_DefaultPrivate_RFC1918Trusted(t *testing.T) {


### PR DESCRIPTION
## Summary

Regression from 0.29.0. The forwarded-headers middleware set `r.URL.Scheme = proto` for trusted proxies. A server request's `r.URL` is origin-form (path only — the host lives in `r.Host`), so setting just the scheme made `r.URL.String()` return `https:///path`. This surfaced as garbled request-log URLs behind ngrok (`GET https:///auth/login`, `url.full=…ngrok-free.devhttps:///auth/login`) and would corrupt any absolute URL built from `r.URL`.

The scheme signal is unchanged for every consumer: `burrow.RequestIsHTTPS` reads the request-context flag (and the `r.TLS` sentinel), CSRF/session go through `RequestIsHTTPS`, and `unrolled/secure`'s `isSSL` is satisfied by the `r.TLS` sentinel — none of them needed `r.URL.Scheme`. So the fix is to simply stop mutating `r.URL`.

## Test plan

- New `TestForwarded_DoesNotCorruptURL`: an **origin-form** request (`/auth/login`) through a trusted loopback peer with `X-Forwarded-Proto: https` keeps `r.URL.String() == "/auth/login"`, while `RequestIsHTTPS` is still true and the `r.TLS` sentinel is set. (The existing tests used absolute URLs, which masked the bug.)
- Dropped the now-incorrect `r.URL.Scheme == "https"` assertion from `TestForwarded_DefaultPrivate_LoopbackTrusted`.
- `go test ./... -race` green; `golangci-lint` 0 issues; `mise run docs-build` clean.