### PR TITLE
feat(tasks): add batch-enqueue API (EnqueueBatch/EnqueueBatchAt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Burrow are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Breaking Changes
+
+- **`tasks.Enqueuer` gains `EnqueueBatch` and `EnqueueBatchAt`.** Custom `Enqueuer`/`Queue` implementations (including test mocks) must add both methods; apps using `contrib/jobs` are unaffected. See the [v0.30 migration guide](https://burrow.andrich.dev/migration/v0.30/).
+
+### Added
+
+- **Batch enqueueing: `EnqueueBatch` / `EnqueueBatchAt`.** N jobs of one type insert in a single all-or-nothing transaction (one commit instead of N) — for fan-out callers like one delivery job per follower. On `Enqueuer`/`Queue`, the typed task wrappers, and `contrib/jobs`; see the [Jobs guide](https://burrow.andrich.dev/contrib/jobs/#batch-enqueueing).
+
 ## 0.29.1 — 2026-06-04
 
 ### Fixed

--- a/contrib/auth/email_jobs_test.go
+++ b/contrib/auth/email_jobs_test.go
@@ -46,6 +46,19 @@ func (q *mockQueue) EnqueueAt(_ context.Context, typeName string, payload any, _
 	return "job-1", nil
 }
 
+func (q *mockQueue) EnqueueBatch(_ context.Context, typeName string, payloads []any) ([]string, error) {
+	ids := make([]string, len(payloads))
+	for i, payload := range payloads {
+		q.enqueued = append(q.enqueued, mockEnqueuedJob{typeName: typeName, payload: payload})
+		ids[i] = "job-1"
+	}
+	return ids, nil
+}
+
+func (q *mockQueue) EnqueueBatchAt(ctx context.Context, typeName string, payloads []any, _ time.Time) ([]string, error) {
+	return q.EnqueueBatch(ctx, typeName, payloads)
+}
+
 func (q *mockQueue) Dequeue(_ context.Context, id string) error {
 	q.dequeued = append(q.dequeued, id)
 	return nil

--- a/contrib/jobs/app.go
+++ b/contrib/jobs/app.go
@@ -213,6 +213,44 @@ func (a *App) EnqueueAt(ctx context.Context, typeName string, payload any, runAt
 	return job.ID, nil
 }
 
+// EnqueueBatch adds a batch of jobs of one type for immediate processing
+// (see tasks.Enqueuer for the batch contract).
+func (a *App) EnqueueBatch(ctx context.Context, typeName string, payloads []any) ([]string, error) {
+	return a.EnqueueBatchAt(ctx, typeName, payloads, time.Now())
+}
+
+// EnqueueBatchAt adds a batch of jobs of one type scheduled for a specific
+// time (see tasks.Enqueuer for the batch contract).
+func (a *App) EnqueueBatchAt(ctx context.Context, typeName string, payloads []any, runAt time.Time) ([]string, error) {
+	if _, ok := a.handlers[typeName]; !ok {
+		return nil, fmt.Errorf("jobs: unknown type %q (not registered via Handle)", typeName)
+	}
+	if len(payloads) == 0 {
+		return nil, nil
+	}
+
+	// Marshal everything up front so a bad payload rejects the whole batch
+	// before anything reaches the database.
+	encoded := make([]string, len(payloads))
+	for i, payload := range payloads {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("jobs: marshal payload %d for %q: %w", i, typeName, err)
+		}
+		encoded[i] = string(data)
+	}
+
+	jobs, err := a.repo.EnqueueBatch(ctx, typeName, encoded, a.retries[typeName], a.priorities[typeName], runAt)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(jobs))
+	for i, job := range jobs {
+		ids[i] = job.ID
+	}
+	return ids, nil
+}
+
 // Dequeue cancels a pending job by its ID.
 func (a *App) Dequeue(ctx context.Context, id string) error {
 	return a.repo.Cancel(ctx, id)

--- a/contrib/jobs/app_test.go
+++ b/contrib/jobs/app_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"sync/atomic"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/oliverandrich/burrow"
 	"github.com/oliverandrich/burrow/burrowtest"
 	"github.com/oliverandrich/burrow/registry"
+	"github.com/oliverandrich/den"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
@@ -102,6 +104,132 @@ func TestApp_Enqueue_InvalidPayload(t *testing.T) {
 	_, err := app.Enqueue(context.Background(), "test", make(chan int))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "marshal payload")
+}
+
+func TestApp_EnqueueBatch(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+
+	app.Handle("fanout", func(_ context.Context, _ []byte) error {
+		return nil
+	}, burrow.WithMaxRetries(5), burrow.WithPriority(2))
+
+	ids, err := app.EnqueueBatch(context.Background(), "fanout",
+		[]any{map[string]int{"n": 1}, map[string]int{"n": 2}, map[string]int{"n": 3}})
+	require.NoError(t, err)
+	require.Len(t, ids, 3)
+
+	// IDs come back in input order with the type's retry/priority settings.
+	for i, id := range ids {
+		job, err := app.repo.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, "fanout", job.Type)
+		assert.JSONEq(t, fmt.Sprintf(`{"n":%d}`, i+1), job.Payload)
+		assert.Equal(t, StatusPending, job.Status)
+		assert.Equal(t, 5, job.MaxRetries)
+		assert.Equal(t, 2, job.Priority)
+	}
+}
+
+func TestApp_EnqueueBatchAt(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+
+	app.Handle("fanout", func(_ context.Context, _ []byte) error { return nil })
+
+	future := time.Now().Add(time.Hour)
+	ids, err := app.EnqueueBatchAt(context.Background(), "fanout", []any{"a", "b"}, future)
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+
+	for _, id := range ids {
+		job, err := app.repo.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		assert.WithinDuration(t, future, job.RunAt, time.Second)
+	}
+}
+
+func TestApp_EnqueueBatch_UnknownType(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+
+	_, err := app.EnqueueBatch(context.Background(), "nonexistent", []any{"x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown type")
+
+	// The type check runs before the empty check — an empty batch for an
+	// unregistered type still errors, catching wiring bugs.
+	_, err = app.EnqueueBatch(context.Background(), "nonexistent", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown type")
+}
+
+func TestApp_EnqueueBatch_Empty(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+
+	app.Handle("fanout", func(_ context.Context, _ []byte) error { return nil })
+
+	ids, err := app.EnqueueBatch(context.Background(), "fanout", nil)
+	require.NoError(t, err)
+	assert.Nil(t, ids)
+}
+
+func TestApp_EnqueueBatch_InvalidPayload(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+
+	app.Handle("fanout", func(_ context.Context, _ []byte) error { return nil })
+
+	// Index 1 cannot be marshaled — the whole batch must be rejected before
+	// anything reaches the database.
+	_, err := app.EnqueueBatch(context.Background(), "fanout", []any{"valid", make(chan int)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal payload 1")
+
+	count, err := den.NewQuery[Job](db).Count(context.Background())
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, count)
+}
+
+func TestApp_EnqueueBatch_FullLifecycle(t *testing.T) {
+	db := testDB(t)
+	app := New()
+	app.repo = NewRepository(db)
+
+	var processed atomic.Int32
+	app.Handle("batch-lifecycle", func(_ context.Context, _ []byte) error {
+		processed.Add(1)
+		return nil
+	})
+
+	cfg := testWorkerConfig()
+	ctx, cancel := context.WithCancel(context.Background())
+	app.cancelFunc = cancel
+	app.worker = NewWorker(app.repo, app.handlers, cfg, nil)
+	go app.worker.Start(ctx)
+
+	ids, err := app.EnqueueBatch(context.Background(), "batch-lifecycle", []any{"a", "b", "c"})
+	require.NoError(t, err)
+	require.Len(t, ids, 3)
+
+	require.Eventually(t, func() bool {
+		return processed.Load() == 3
+	}, 2*time.Second, 10*time.Millisecond)
+
+	for _, id := range ids {
+		job, err := app.repo.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, StatusCompleted, job.Status)
+	}
+
+	err = app.Shutdown(context.Background())
+	require.NoError(t, err)
 }
 
 func TestApp_FullLifecycle(t *testing.T) {

--- a/contrib/jobs/app_test.go
+++ b/contrib/jobs/app_test.go
@@ -218,15 +218,18 @@ func TestApp_EnqueueBatch_FullLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ids, 3)
 
+	// Poll the job statuses, not the handler counter — the worker marks a job
+	// completed only after its handler returns.
 	require.Eventually(t, func() bool {
-		return processed.Load() == 3
+		for _, id := range ids {
+			job, err := app.repo.GetByID(context.Background(), id)
+			if err != nil || job.Status != StatusCompleted {
+				return false
+			}
+		}
+		return true
 	}, 2*time.Second, 10*time.Millisecond)
-
-	for _, id := range ids {
-		job, err := app.repo.GetByID(context.Background(), id)
-		require.NoError(t, err)
-		assert.Equal(t, StatusCompleted, job.Status)
-	}
+	assert.EqualValues(t, 3, processed.Load())
 
 	err = app.Shutdown(context.Background())
 	require.NoError(t, err)

--- a/contrib/jobs/repository.go
+++ b/contrib/jobs/repository.go
@@ -32,9 +32,9 @@ func NewRepository(db *den.DB) *Repository {
 	return &Repository{db: db}
 }
 
-// Enqueue inserts a new job into the queue.
-func (r *Repository) Enqueue(ctx context.Context, typeName, payload string, maxRetries, priority int, runAt time.Time) (*Job, error) {
-	job := &Job{
+// newPendingJob builds the Job row shared by the single and batch insert paths.
+func newPendingJob(typeName, payload string, maxRetries, priority int, runAt time.Time) *Job {
+	return &Job{
 		Type:       typeName,
 		Payload:    payload,
 		Status:     StatusPending,
@@ -42,10 +42,32 @@ func (r *Repository) Enqueue(ctx context.Context, typeName, payload string, maxR
 		MaxRetries: maxRetries,
 		RunAt:      runAt,
 	}
+}
+
+// Enqueue inserts a new job into the queue.
+func (r *Repository) Enqueue(ctx context.Context, typeName, payload string, maxRetries, priority int, runAt time.Time) (*Job, error) {
+	job := newPendingJob(typeName, payload, maxRetries, priority, runAt)
 	if err := den.Save(ctx, r.db, job); err != nil {
 		return nil, fmt.Errorf("enqueue job %q: %w", typeName, err)
 	}
 	return job, nil
+}
+
+// EnqueueBatch inserts a batch of jobs of the same type in a single
+// transaction (den.SaveAll), all-or-nothing. Jobs are returned in input order
+// with their IDs populated; an empty payloads slice is a no-op returning nil.
+func (r *Repository) EnqueueBatch(ctx context.Context, typeName string, payloads []string, maxRetries, priority int, runAt time.Time) ([]*Job, error) {
+	if len(payloads) == 0 {
+		return nil, nil
+	}
+	jobs := make([]*Job, len(payloads))
+	for i, payload := range payloads {
+		jobs[i] = newPendingJob(typeName, payload, maxRetries, priority, runAt)
+	}
+	if err := den.SaveAll(ctx, r.db, jobs); err != nil {
+		return nil, fmt.Errorf("enqueue batch %q: %w", typeName, err)
+	}
+	return jobs, nil
 }
 
 // Claim atomically claims up to limit pending or failed jobs that are ready to run.

--- a/contrib/jobs/repository_test.go
+++ b/contrib/jobs/repository_test.go
@@ -38,6 +38,65 @@ func TestRepository_Enqueue(t *testing.T) {
 	assert.Equal(t, 3, job.MaxRetries)
 }
 
+func TestRepository_EnqueueBatch(t *testing.T) {
+	db := testDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	runAt := time.Now()
+	payloads := []string{`{"n":1}`, `{"n":2}`, `{"n":3}`}
+	jobs, err := repo.EnqueueBatch(ctx, "deliver", payloads, 5, 2, runAt)
+	require.NoError(t, err)
+	require.Len(t, jobs, 3)
+
+	seen := make(map[string]bool)
+	for i, job := range jobs {
+		assert.NotEmpty(t, job.ID)
+		assert.False(t, seen[job.ID], "IDs must be distinct")
+		seen[job.ID] = true
+		assert.Equal(t, "deliver", job.Type)
+		assert.JSONEq(t, payloads[i], job.Payload, "jobs must be returned in input order")
+		assert.Equal(t, StatusPending, job.Status)
+		assert.Equal(t, 5, job.MaxRetries)
+		assert.Equal(t, 2, job.Priority)
+		assert.WithinDuration(t, runAt, job.RunAt, time.Second)
+	}
+
+	count, err := den.NewQuery[Job](db).Count(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, count)
+}
+
+func TestRepository_EnqueueBatch_Empty(t *testing.T) {
+	db := testDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	jobs, err := repo.EnqueueBatch(ctx, "deliver", nil, 3, 0, time.Now())
+	require.NoError(t, err)
+	assert.Nil(t, jobs)
+
+	count, err := den.NewQuery[Job](db).Count(ctx)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, count)
+}
+
+func TestRepository_EnqueueBatch_CancelledContext(t *testing.T) {
+	db := testDB(t)
+	repo := NewRepository(db)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := repo.EnqueueBatch(cancelled, "deliver", []string{`{}`, `{}`}, 3, 0, time.Now())
+	require.Error(t, err)
+
+	// Atomicity: the failed batch must not leave partial rows behind.
+	count, err := den.NewQuery[Job](db).Count(context.Background())
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, count)
+}
+
 func TestRepository_Claim(t *testing.T) {
 	db := testDB(t)
 	repo := NewRepository(db)

--- a/docs/contrib/jobs.md
+++ b/docs/contrib/jobs.md
@@ -91,7 +91,7 @@ func (a *App) RegisterJobs(q burrow.Queue) {
 jobID, err := a.jobs.Enqueue(ctx, "process-upload", map[string]string{"image_id": "123"})
 ```
 
-The `Enqueuer` interface (`Enqueue`, `EnqueueAt`, `Dequeue`) is available for code that only needs to submit jobs without registering handlers. `Queue` embeds `Enqueuer` and adds `Handle`.
+The `Enqueuer` interface (`Enqueue`, `EnqueueAt`, `EnqueueBatch`, `EnqueueBatchAt`, `Dequeue`) is available for code that only needs to submit jobs without registering handlers. `Queue` embeds `Enqueuer` and adds `Handle`.
 
 ## Enqueueing Jobs
 
@@ -107,6 +107,22 @@ jobID, err := jobsApp.Enqueue(ctx, "send-welcome-email", payload)
 ```
 
 The payload can be any value that `json.Marshal` can serialise. The type must be registered via `Handle()` or `TaskDefinition.Register()` — unknown types return an error.
+
+### Batch enqueueing
+
+When one event fans out into many jobs of the same type (say, one delivery job per follower), `EnqueueBatch` / `EnqueueBatchAt` insert all of them in a single transaction — one commit instead of N independently committed writes:
+
+```go
+var deliverPost = burrow.DefineTask("deliver-post", deliverHandler)
+
+// Typed — payloads is a []DeliveryPayload
+ids, err := deliverPost.EnqueueBatch(ctx, payloads)
+
+// Or via the raw Queue interface:
+ids, err := jobsApp.EnqueueBatch(ctx, "deliver-post", []any{p1, p2, p3})
+```
+
+The insert is all-or-nothing — a payload that fails to marshal rejects the whole batch before anything reaches the database. Job IDs are returned in input order, and an empty slice is a no-op. Each job stays independent after insertion (own retries, own priority from its type), and since all jobs in a batch share one `RunAt`, their relative execution order is not guaranteed.
 
 ## Priority
 

--- a/docs/migration/v0.30.md
+++ b/docs/migration/v0.30.md
@@ -1,0 +1,45 @@
+# Migrating to v0.30
+
+v0.30 adds batch enqueueing to the job queue. The feature itself is additive —
+the one breaking change is that the `Enqueuer` interface (and therefore `Queue`)
+gains two methods, which affects custom implementations and test mocks.
+
+For the full list of changes, see the [v0.30 changelog](../changelog.md).
+
+## Quick orientation
+
+| What you used | What changes | Section |
+|---|---|---|
+| `contrib/jobs` as your Queue | Nothing — new methods are provided | — |
+| A custom `Enqueuer`/`Queue` implementation or test mock | Must add `EnqueueBatch` + `EnqueueBatchAt` | [Enqueuer interface](#enqueuer-gains-batch-methods) |
+| (nothing) | New `EnqueueBatch`/`EnqueueBatchAt` on tasks and the queue | [New: batch enqueueing](#new-batch-enqueueing) |
+
+## Enqueuer gains batch methods
+
+`tasks.Enqueuer` now includes `EnqueueBatch` and `EnqueueBatchAt`. Anything
+implementing `Enqueuer` or `Queue` — typically test mocks — needs both:
+
+```go
+// Add to your mock/implementation:
+func (q *mockQueue) EnqueueBatch(ctx context.Context, typeName string, payloads []any) ([]string, error) {
+    return q.EnqueueBatchAt(ctx, typeName, payloads, time.Now())
+}
+
+func (q *mockQueue) EnqueueBatchAt(ctx context.Context, typeName string, payloads []any, runAt time.Time) ([]string, error) {
+    ids := make([]string, len(payloads))
+    for i := range payloads {
+        ids[i] = "job-1" // record/stub as your test needs
+    }
+    return ids, nil
+}
+```
+
+The contract for real implementations: the insert is atomic (all payloads
+become jobs or none do), IDs return in input order, and an empty slice returns
+`(nil, nil)` without touching the queue.
+
+## New: batch enqueueing
+
+Nothing to migrate — `EnqueueBatch`/`EnqueueBatchAt` insert N jobs of one type
+in a single transaction, on the typed task wrappers and the raw queue alike.
+See the [Jobs guide](../contrib/jobs.md#batch-enqueueing).

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -13,7 +13,7 @@ Full signatures live on [pkg.go.dev](https://pkg.go.dev/github.com/oliverandrich
 | Symbol | Notes |
 |---|---|
 | `Queue` | Embeds `Enqueuer` plus `Handle(typeName, fn, opts...)` for handler registration |
-| `Enqueuer` | `Enqueue(ctx, typeName, payload)`, `EnqueueAt(ctx, typeName, payload, runAt)`, `Dequeue(ctx, id)` — for code that only submits |
+| `Enqueuer` | `Enqueue(ctx, typeName, payload)`, `EnqueueAt(ctx, typeName, payload, runAt)`, `EnqueueBatch(ctx, typeName, payloads)`, `EnqueueBatchAt(ctx, typeName, payloads, runAt)`, `Dequeue(ctx, id)` — for code that only submits |
 | `HasJobs` | App capability — `RegisterJobs(q Queue)` called once during PostConfigure |
 | `JobHandlerFunc` | `func(ctx, []byte) error` — raw handler signature |
 
@@ -21,7 +21,7 @@ Full signatures live on [pkg.go.dev](https://pkg.go.dev/github.com/oliverandrich
 
 | Symbol | Notes |
 |---|---|
-| `TaskDefinition[P any]` | Generic typed task; ships a `Register` method to wire it into a Queue and `Enqueue` / `EnqueueAt` methods that marshal the payload |
+| `TaskDefinition[P any]` | Generic typed task; ships a `Register` method to wire it into a Queue and `Enqueue` / `EnqueueAt` / `EnqueueBatch` / `EnqueueBatchAt` methods that marshal the payload(s) |
 | `DefineTask[P](name, handler, opts...)` | Constructor — handler is `func(ctx, P) error` |
 | `ResultTask[P, R any]` | Like `TaskDefinition` but the handler returns a value that the worker stores via `ResultCapture` |
 | `DefineResultTask[P, R](name, handler, opts...)` | Constructor — handler is `func(ctx, P) (R, error)` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
       - Context Helpers: reference/context-helpers.md
       - CLI: reference/cli.md
   - Migration:
+      - "v0.30": migration/v0.30.md
       - "v0.27": migration/v0.27.md
       - "v0.25": migration/v0.25.md
       - "v0.24": migration/v0.24.md

--- a/tasks/queue.go
+++ b/tasks/queue.go
@@ -33,9 +33,17 @@ func WithPriority(n int) JobOption {
 
 // Enqueuer provides job submission and cancellation. Use this interface
 // for code that only needs to enqueue jobs, not register handlers.
+//
+// EnqueueBatch and EnqueueBatchAt insert N jobs of one type atomically:
+// either every payload becomes a job or none does. Job IDs are returned in
+// input order, an empty payloads slice returns (nil, nil) without touching
+// the queue, and each job keeps the independent retry/priority semantics of
+// its type — only the insert is batched.
 type Enqueuer interface {
 	Enqueue(ctx context.Context, typeName string, payload any) (string, error)
 	EnqueueAt(ctx context.Context, typeName string, payload any, runAt time.Time) (string, error)
+	EnqueueBatch(ctx context.Context, typeName string, payloads []any) ([]string, error)
+	EnqueueBatchAt(ctx context.Context, typeName string, payloads []any, runAt time.Time) ([]string, error)
 	Dequeue(ctx context.Context, id string) error
 }
 

--- a/tasks/result.go
+++ b/tasks/result.go
@@ -103,6 +103,20 @@ func (t *ResultTask[P, R]) EnqueueAt(ctx context.Context, payload P, runAt time.
 	return t.queue.EnqueueAt(ctx, t.name, payload, runAt)
 }
 
+// EnqueueBatch enqueues all payloads for immediate processing in one atomic
+// insert (see Enqueuer for the batch contract). Panics if called before Register.
+func (t *ResultTask[P, R]) EnqueueBatch(ctx context.Context, payloads []P) ([]string, error) {
+	t.mustBeRegistered()
+	return t.queue.EnqueueBatch(ctx, t.name, toAnySlice(payloads))
+}
+
+// EnqueueBatchAt enqueues all payloads for processing at the given time in one
+// atomic insert (see Enqueuer for the batch contract). Panics if called before Register.
+func (t *ResultTask[P, R]) EnqueueBatchAt(ctx context.Context, payloads []P, runAt time.Time) ([]string, error) {
+	t.mustBeRegistered()
+	return t.queue.EnqueueBatchAt(ctx, t.name, toAnySlice(payloads), runAt)
+}
+
 func (t *ResultTask[P, R]) mustBeRegistered() {
 	if t.queue == nil {
 		panic(fmt.Sprintf("burrow: ResultTask %q used before Register was called", t.name))

--- a/tasks/result_test.go
+++ b/tasks/result_test.go
@@ -63,6 +63,50 @@ func TestResultTask_EnqueueAt(t *testing.T) {
 	assert.Equal(t, "job-456", id)
 }
 
+func TestResultTask_EnqueueBatch(t *testing.T) {
+	task := tasks.DefineResultTask("batch-compute", func(_ context.Context, _ resultPayload) (resultOutput, error) {
+		return resultOutput{}, nil
+	})
+
+	q := newMockQueue()
+	task.Register(q)
+
+	payloads := []resultPayload{{Input: "a"}, {Input: "b"}}
+	ids, err := task.EnqueueBatch(context.Background(), payloads)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"job-b1", "job-b2"}, ids)
+	assert.Equal(t, "batch-compute", q.batchType)
+	assert.Equal(t, []any{payloads[0], payloads[1]}, q.batchPayloads)
+}
+
+func TestResultTask_EnqueueBatchAt(t *testing.T) {
+	task := tasks.DefineResultTask("batch-later", func(_ context.Context, _ resultPayload) (resultOutput, error) {
+		return resultOutput{}, nil
+	})
+
+	q := newMockQueue()
+	task.Register(q)
+
+	runAt := time.Now().Add(time.Hour)
+	ids, err := task.EnqueueBatchAt(context.Background(), []resultPayload{{Input: "later"}}, runAt)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"job-b1"}, ids)
+	assert.Equal(t, runAt, q.batchRunAt)
+}
+
+func TestResultTask_EnqueueBatchBeforeRegister(t *testing.T) {
+	task := tasks.DefineResultTask("unregistered", func(_ context.Context, _ resultPayload) (resultOutput, error) {
+		return resultOutput{}, nil
+	})
+
+	assert.PanicsWithValue(t,
+		`burrow: ResultTask "unregistered" used before Register was called`,
+		func() {
+			_, _ = task.EnqueueBatch(context.Background(), []resultPayload{{}})
+		},
+	)
+}
+
 func TestResultTask_Name(t *testing.T) {
 	task := tasks.DefineResultTask("my-task", func(_ context.Context, _ resultPayload) (resultOutput, error) {
 		return resultOutput{}, nil

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -72,6 +72,28 @@ func (t *TaskDefinition[P]) EnqueueAt(ctx context.Context, payload P, runAt time
 	return t.queue.EnqueueAt(ctx, t.name, payload, runAt)
 }
 
+// EnqueueBatch enqueues all payloads for immediate processing in one atomic
+// insert (see Enqueuer for the batch contract). Panics if called before Register.
+func (t *TaskDefinition[P]) EnqueueBatch(ctx context.Context, payloads []P) ([]string, error) {
+	t.mustBeRegistered()
+	return t.queue.EnqueueBatch(ctx, t.name, toAnySlice(payloads))
+}
+
+// EnqueueBatchAt enqueues all payloads for processing at the given time in one
+// atomic insert (see Enqueuer for the batch contract). Panics if called before Register.
+func (t *TaskDefinition[P]) EnqueueBatchAt(ctx context.Context, payloads []P, runAt time.Time) ([]string, error) {
+	t.mustBeRegistered()
+	return t.queue.EnqueueBatchAt(ctx, t.name, toAnySlice(payloads), runAt)
+}
+
+func toAnySlice[P any](payloads []P) []any {
+	anys := make([]any, len(payloads))
+	for i, p := range payloads {
+		anys[i] = p
+	}
+	return anys
+}
+
 func (t *TaskDefinition[P]) mustBeRegistered() {
 	if t.queue == nil {
 		panic(fmt.Sprintf("burrow: TaskDefinition %q used before Register was called", t.name))

--- a/tasks/task_test.go
+++ b/tasks/task_test.go
@@ -2,6 +2,7 @@ package tasks_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,10 +18,13 @@ type testPayload struct {
 
 // mockQueue records Handle and Enqueue calls for testing TaskDefinition.
 type mockQueue struct {
-	handlers map[string]tasks.JobHandlerFunc
-	opts     map[string][]tasks.JobOption
-	lastType string
-	lastData any
+	handlers      map[string]tasks.JobHandlerFunc
+	opts          map[string][]tasks.JobOption
+	lastType      string
+	lastData      any
+	batchType     string
+	batchPayloads []any
+	batchRunAt    time.Time
 }
 
 func newMockQueue() *mockQueue {
@@ -45,6 +49,21 @@ func (q *mockQueue) EnqueueAt(ctx context.Context, typeName string, payload any,
 	q.lastType = typeName
 	q.lastData = payload
 	return "job-456", nil
+}
+
+func (q *mockQueue) EnqueueBatch(ctx context.Context, typeName string, payloads []any) ([]string, error) {
+	return q.EnqueueBatchAt(ctx, typeName, payloads, time.Time{})
+}
+
+func (q *mockQueue) EnqueueBatchAt(_ context.Context, typeName string, payloads []any, runAt time.Time) ([]string, error) {
+	q.batchType = typeName
+	q.batchPayloads = payloads
+	q.batchRunAt = runAt
+	ids := make([]string, len(payloads))
+	for i := range ids {
+		ids[i] = fmt.Sprintf("job-b%d", i+1)
+	}
+	return ids, nil
 }
 
 func (q *mockQueue) Dequeue(ctx context.Context, id string) error {
@@ -99,6 +118,64 @@ func TestTaskDefinition_EnqueueAt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "job-456", id)
 	assert.Equal(t, "delayed-task", q.lastType)
+}
+
+func TestTaskDefinition_EnqueueBatch(t *testing.T) {
+	task := tasks.DefineTask("fanout", func(_ context.Context, _ testPayload) error {
+		return nil
+	})
+
+	q := newMockQueue()
+	task.Register(q)
+
+	payloads := []testPayload{{To: "a@b.com"}, {To: "c@d.com"}, {To: "e@f.com"}}
+	ids, err := task.EnqueueBatch(context.Background(), payloads)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"job-b1", "job-b2", "job-b3"}, ids)
+	assert.Equal(t, "fanout", q.batchType)
+	assert.Equal(t, []any{payloads[0], payloads[1], payloads[2]}, q.batchPayloads)
+}
+
+func TestTaskDefinition_EnqueueBatchAt(t *testing.T) {
+	task := tasks.DefineTask("fanout-later", func(_ context.Context, _ testPayload) error {
+		return nil
+	})
+
+	q := newMockQueue()
+	task.Register(q)
+
+	runAt := time.Now().Add(time.Hour)
+	ids, err := task.EnqueueBatchAt(context.Background(), []testPayload{{To: "a@b.com"}}, runAt)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"job-b1"}, ids)
+	assert.Equal(t, "fanout-later", q.batchType)
+	assert.Equal(t, runAt, q.batchRunAt)
+}
+
+func TestTaskDefinition_EnqueueBatchBeforeRegister(t *testing.T) {
+	task := tasks.DefineTask("unregistered", func(_ context.Context, _ testPayload) error {
+		return nil
+	})
+
+	assert.PanicsWithValue(t,
+		`burrow: TaskDefinition "unregistered" used before Register was called`,
+		func() {
+			_, _ = task.EnqueueBatch(context.Background(), []testPayload{{}})
+		},
+	)
+}
+
+func TestTaskDefinition_EnqueueBatchAtBeforeRegister(t *testing.T) {
+	task := tasks.DefineTask("unregistered", func(_ context.Context, _ testPayload) error {
+		return nil
+	})
+
+	assert.PanicsWithValue(t,
+		`burrow: TaskDefinition "unregistered" used before Register was called`,
+		func() {
+			_, _ = task.EnqueueBatchAt(context.Background(), []testPayload{{}}, time.Now())
+		},
+	)
 }
 
 func TestTaskDefinition_EnqueueBeforeRegister(t *testing.T) {


### PR DESCRIPTION
## Summary

- `tasks.Enqueuer` gains `EnqueueBatch(ctx, typeName, payloads []any)` and `EnqueueBatchAt(..., runAt)` — N jobs of one type insert in a single all-or-nothing transaction (one commit instead of N independently committed writes). Motivation: fan-out callers (e.g. one ActivityPub delivery job per follower) currently pay N serial INSERTs on the request path.
- Typed wrappers `TaskDefinition[P].EnqueueBatch(At)` / `ResultTask[P, R].EnqueueBatch(At)` marshal `[]P` and delegate.
- `contrib/jobs`: `App.EnqueueBatch(At)` validates the type is registered (before the empty-slice check), marshals all payloads up front (a bad payload rejects the whole batch with its index in the error), then `Repository.EnqueueBatch` persists via `den.SaveAll`. Job IDs return in input order; per-type retry/priority semantics unchanged — each row stays an independent job.

**Breaking change**: custom `Enqueuer`/`Queue` implementations (including test mocks) must add both methods; apps using `contrib/jobs` are unaffected. Migration guide: `docs/migration/v0.30.md`.

Worker, claim, and admin UI need no changes — batch-inserted rows are ordinary pending jobs.

## Test plan

- [x] Repository: batch insert (order, distinct IDs, fields), empty no-op, cancelled-context atomicity (zero partial rows)
- [x] tasks: typed batch enqueue for `TaskDefinition` and `ResultTask`, runAt pass-through, panics before `Register`
- [x] App: ID order + per-type retries/priority, runAt propagation, unknown type (also with empty slice), empty no-op, marshal failure leaves zero rows
- [x] End-to-end: worker pool drains a batch of 3 to `completed`
- [x] `go build ./...`, full suite (1961 tests), `golangci-lint` clean, `mise run docs-build` warning-free